### PR TITLE
Legg til avhengigheter mellom spørsmål i en Bostedsland

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     needs: [ build ]
-    if: github.ref == 'refs/heads/avhengigheter'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: dev-gcp
     steps:
@@ -56,18 +56,18 @@ jobs:
           VARS: .nais/vars-dev.yaml
           VAR: image=${{ needs.build.outputs.image }}
 
-#  deploy-prod:
-#    name: Deploy to prod
-#    needs: [ build ]
-#    if: github.ref == 'refs/heads/main'
-#    runs-on: ubuntu-latest
-#    environment: prod-gcp
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: nais/deploy/actions/deploy@v2
-#        env:
-#          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-#          CLUSTER: prod-gcp
-#          RESOURCE: .nais/app.yaml
-#          VARS: .nais/vars-prod.yaml
-#          VAR: image=${{ needs.build.outputs.image }}
+  deploy-prod:
+    name: Deploy to prod
+    needs: [ build ]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: prod-gcp
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nais/deploy/actions/deploy@v2
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: .nais/app.yaml
+          VARS: .nais/vars-prod.yaml
+          VAR: image=${{ needs.build.outputs.image }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     needs: [ build ]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/avhengigheter'
     runs-on: ubuntu-latest
     environment: dev-gcp
     steps:
@@ -56,18 +56,18 @@ jobs:
           VARS: .nais/vars-dev.yaml
           VAR: image=${{ needs.build.outputs.image }}
 
-  deploy-prod:
-    name: Deploy to prod
-    needs: [ build ]
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    environment: prod-gcp
-    steps:
-      - uses: actions/checkout@v4
-      - uses: nais/deploy/actions/deploy@v2
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: .nais/app.yaml
-          VARS: .nais/vars-prod.yaml
-          VAR: image=${{ needs.build.outputs.image }}
+#  deploy-prod:
+#    name: Deploy to prod
+#    needs: [ build ]
+#    if: github.ref == 'refs/heads/main'
+#    runs-on: ubuntu-latest
+#    environment: prod-gcp
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: nais/deploy/actions/deploy@v2
+#        env:
+#          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+#          CLUSTER: prod-gcp
+#          RESOURCE: .nais/app.yaml
+#          VARS: .nais/vars-prod.yaml
+#          VAR: image=${{ needs.build.outputs.image }}

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/spørsmål/grupper/Bostedsland.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/spørsmål/grupper/Bostedsland.kt
@@ -33,6 +33,8 @@ abstract class Bostedsland {
     abstract fun nesteSpørsmål(aktivtSpørsmål: SporsmalDTO): GrunnleggendeSpørsmål?
 
     abstract fun getSpørsmålMedId(id: Int): GrunnleggendeSpørsmål
+
+    abstract fun avhengigheter(id: Int): List<Int>
 }
 
 object BostedslandDTOV1 : Bostedsland() {
@@ -108,6 +110,24 @@ object BostedslandDTOV1 : Bostedsland() {
             hvorforReisteFraNorge.idIGruppe -> hvorforReisteFraNorge
             enGangIUken.idIGruppe -> enGangIUken
             rotasjon.idIGruppe -> rotasjon
+            else -> throw IllegalArgumentException("Ukjent spørsmål med id: $id")
+        }
+
+    override fun avhengigheter(id: Int): List<Int> =
+        when (id) {
+            hvilketLandBorDuI.idIGruppe ->
+                listOf(
+                    reistTilbakeTilNorge.idIGruppe,
+                    datoForAvreise.idIGruppe,
+                    hvorforReisteFraNorge.idIGruppe,
+                    enGangIUken.idIGruppe,
+                    rotasjon.idIGruppe,
+                )
+            reistTilbakeTilNorge.idIGruppe -> listOf(datoForAvreise.idIGruppe, hvorforReisteFraNorge.idIGruppe)
+            datoForAvreise.idIGruppe -> listOf(hvorforReisteFraNorge.idIGruppe)
+            hvorforReisteFraNorge.idIGruppe -> emptyList()
+            enGangIUken.idIGruppe -> listOf(rotasjon.idIGruppe)
+            rotasjon.idIGruppe -> emptyList()
             else -> throw IllegalArgumentException("Ukjent spørsmål med id: $id")
         }
 }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadService.kt
@@ -5,6 +5,7 @@ import no.nav.dagpenger.soknad.orkestrator.api.models.SporsmaalgruppeNavnDTO
 import no.nav.dagpenger.soknad.orkestrator.api.models.SporsmalDTO
 import no.nav.dagpenger.soknad.orkestrator.api.models.SporsmalgruppeDTO
 import no.nav.dagpenger.soknad.orkestrator.metrikker.SøknadMetrikker
+import no.nav.dagpenger.soknad.orkestrator.spørsmål.grupper.Bostedsland
 import no.nav.dagpenger.soknad.orkestrator.spørsmål.grupper.BostedslandDTOV1
 import no.nav.dagpenger.soknad.orkestrator.spørsmål.grupper.getGruppe
 import no.nav.dagpenger.soknad.orkestrator.spørsmål.grupper.toSporsmalDTO
@@ -68,6 +69,12 @@ class SøknadService(
 
         val gruppe = getGruppe(lagretInfo.gruppeId)
 
+        nullstillAvhengigheter(
+            søknadId = søknadId,
+            gruppe = gruppe,
+            idIGruppe = lagretInfo.idIGruppe,
+        )
+
         gruppe.nesteSpørsmål(besvartSpørsmål)?.let {
             inMemorySøknadRepository.lagre(
                 spørsmålId = UUID.randomUUID(),
@@ -75,6 +82,22 @@ class SøknadService(
                 gruppeId = lagretInfo.gruppeId,
                 idIGruppe = it.idIGruppe,
                 svar = null,
+            )
+        }
+    }
+
+    fun nullstillAvhengigheter(
+        søknadId: UUID,
+        gruppe: Bostedsland,
+        idIGruppe: Int,
+    ) {
+        val avhengigheter = gruppe.avhengigheter(idIGruppe)
+
+        avhengigheter.forEach {
+            inMemorySøknadRepository.slett(
+                søknadId = søknadId,
+                gruppeId = gruppe.versjon,
+                spørsmålIdIGruppe = it,
             )
         }
     }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/db/InMemorySøknadRepository.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/db/InMemorySøknadRepository.kt
@@ -21,15 +21,27 @@ class InMemorySøknadRepository {
             )
         tabell[søknadId] = tabell[søknadId]
             ?.filter {
-                it.idIGruppe != idIGruppe
+                it.gruppeId != gruppeId || it.idIGruppe != idIGruppe
             }?.plus(dbRad) ?: listOf(dbRad)
+    }
+
+    fun slett(
+        søknadId: UUID,
+        gruppeId: Int,
+        spørsmålIdIGruppe: Int,
+    ) {
+        tabell[søknadId] =
+            tabell[søknadId]
+                ?.filter {
+                    it.gruppeId != gruppeId || it.idIGruppe != spørsmålIdIGruppe
+                }.orEmpty()
     }
 
     fun hent(
         søknadId: UUID,
         gruppeId: Int,
-        spørsmålId: UUID,
-    ): LagretInfo? = tabell[søknadId]?.find { it.spørsmålId == spørsmålId && it.gruppeId == gruppeId }
+        spørsmålIdIGruppe: Int,
+    ): LagretInfo? = tabell[søknadId]?.find { it.gruppeId == gruppeId && it.idIGruppe == spørsmålIdIGruppe }
 
     fun hent(
         søknadId: UUID,


### PR DESCRIPTION
Nå sletter vi de spørsmålene som avhenger av det besvarte spørsmålet.
Kun lagre nesteSpørsmål hvis det ikke finnes fra før, når det kommer et svar.
Det kan være spørsmål med lagrede svar hvis det ikke ble nullstilt da man endret et tidligere svar.
Finn riktig "neste spørsmål" når vi henter neste ved å sortere etter idIGruppe.
Vi fjerner også "fremtidige" besvarte spørsmål fra listen, slik at de først dukker opp når man har kommet til det punktet i søknaden.