### PR TITLE
Legg til auditlogging på database

### DIFF
--- a/.nais/app.yaml
+++ b/.nais/app.yaml
@@ -27,6 +27,11 @@ spec:
           - name : soknad-orkestrator
             envVarPrefix: DB
         tier: db-custom-1-3840
+        flags:
+          - name: cloudsql.enable_pgaudit
+            value: "true"
+          - name: pgaudit.log
+            value: 'write'
   observability:
     autoInstrumentation:
       enabled: true


### PR DESCRIPTION
Dette er en sikkerhetsgreie for at vi skal ha kontroll på hva som gjøres i databaser med data som kan påvirke vedtak/utbetaling.