### PR TITLE
Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      minor-and-patch-bumps:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
Nå blir hver dependency som bumpes av Dependabot egne pull requests. Det blir potensielt mange, og mye klikking for å merge inn til main. Har lyst til å få alle minor- og patch-bumps gruppert i én PR. Major-bumps vil fortsatt blir lagt i individuelle PRer.

La også til Docker i konfigurasjonen, så Dependabot sjekker dependencies der også.