### PR TITLE
PersonaliaApi

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     needs: [ build ]
-    if: github.ref == 'refs/heads/feature/personalia-backend'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: dev-gcp
     steps:
@@ -56,19 +56,18 @@ jobs:
           VARS: .nais/vars-dev.yaml
           VAR: image=${{ needs.build.outputs.image }}
 
-#  deploy-prod:
-#    name: Deploy to prod
-#    needs: [ build ]
-#    if: github.ref == 'refs/heads/main'
-#    runs-on: ubuntu-latest
-#    environment: prod-gcp
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: nais/deploy/actions/deploy@v2
-#        env:
-#          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-#          CLUSTER: prod-gcp
-#          RESOURCE: .nais/app.yaml
-#          VARS: .nais/vars-prod.yaml
-#          VAR: image=${{ needs.build.outputs.image }}
-#
+  deploy-prod:
+    name: Deploy to prod
+    needs: [ build ]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: prod-gcp
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nais/deploy/actions/deploy@v2
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: .nais/app.yaml
+          VARS: .nais/vars-prod.yaml
+          VAR: image=${{ needs.build.outputs.image }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     needs: [ build ]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/feature/personalia-backend'
     runs-on: ubuntu-latest
     environment: dev-gcp
     steps:
@@ -56,18 +56,19 @@ jobs:
           VARS: .nais/vars-dev.yaml
           VAR: image=${{ needs.build.outputs.image }}
 
-  deploy-prod:
-    name: Deploy to prod
-    needs: [ build ]
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    environment: prod-gcp
-    steps:
-      - uses: actions/checkout@v4
-      - uses: nais/deploy/actions/deploy@v2
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: .nais/app.yaml
-          VARS: .nais/vars-prod.yaml
-          VAR: image=${{ needs.build.outputs.image }}
+#  deploy-prod:
+#    name: Deploy to prod
+#    needs: [ build ]
+#    if: github.ref == 'refs/heads/main'
+#    runs-on: ubuntu-latest
+#    environment: prod-gcp
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: nais/deploy/actions/deploy@v2
+#        env:
+#          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+#          CLUSTER: prod-gcp
+#          RESOURCE: .nais/app.yaml
+#          VARS: .nais/vars-prod.yaml
+#          VAR: image=${{ needs.build.outputs.image }}
+#

--- a/.nais/app.yaml
+++ b/.nais/app.yaml
@@ -50,6 +50,12 @@ spec:
       value: {{azure.grupper.saksbehandler}}
     - name: DP_BEHANDLING_SCOPE
       value: {{DP_BEHANDLING_SCOPE}}
+    - name: PDL_API_HOST
+      value: {{PDL_API_HOST}}
+    - name: PDL_API_SCOPE
+      value: {{PDL_API_SCOPE}}
+    - name: PERSON_KONTO_REGISTER_SCOPE
+      value: {{PERSON_KONTO_REGISTER_SCOPE}}
   azure:
     application:
       enabled: true
@@ -75,6 +81,10 @@ spec:
     outbound:
       rules:
         - application: dp-behandling
+        - application: sokos-kontoregister-person
+          namespace: okonomi
+      external:
+        - host: {{PDL_API_HOST}}
   tokenx:
     enabled: true
   {{#if ingresses}}

--- a/.nais/vars-dev.yaml
+++ b/.nais/vars-dev.yaml
@@ -16,6 +16,6 @@ ingresses:
 
 DP_BEHANDLING_SCOPE: "api://dev-gcp.teamdagpenger.dp-behandling/.default"
 DP_BEHANDLING_BASE_URL: "http://dp-behandling"
-PERSON_KONTO_REGISTER_SCOPE: dev-gcp:okonomi:sokos-kontoregister-person
+PERSON_KONTO_REGISTER_SCOPE: "dev-gcp:okonomi:sokos-kontoregister-person"
 PDL_API_HOST: "pdl-api.dev-fss-pub.nais.io"
 PDL_API_SCOPE: "dev-fss:pdl:pdl-api"

--- a/.nais/vars-dev.yaml
+++ b/.nais/vars-dev.yaml
@@ -16,6 +16,6 @@ ingresses:
 
 DP_BEHANDLING_SCOPE: "api://dev-gcp.teamdagpenger.dp-behandling/.default"
 DP_BEHANDLING_BASE_URL: "http://dp-behandling"
-PERSON_KONTO_REGISTER_SCOPE: "dev-gcp:okonomi:sokos-kontoregister-person"
+PERSON_KONTO_REGISTER_SCOPE: dev-gcp:okonomi:sokos-kontoregister-person
 PDL_API_HOST: "pdl-api.dev-fss-pub.nais.io"
 PDL_API_SCOPE: "dev-fss:pdl:pdl-api"

--- a/.nais/vars-dev.yaml
+++ b/.nais/vars-dev.yaml
@@ -16,3 +16,6 @@ ingresses:
 
 DP_BEHANDLING_SCOPE: "api://dev-gcp.teamdagpenger.dp-behandling/.default"
 DP_BEHANDLING_BASE_URL: "http://dp-behandling"
+PERSON_KONTO_REGISTER_SCOPE: "dev-gcp:okonomi:sokos-kontoregister-person"
+PDL_API_HOST: "pdl-api.dev-fss-pub.nais.io"
+PDL_API_SCOPE: "dev-fss:pdl:pdl-api"

--- a/.nais/vars-prod.yaml
+++ b/.nais/vars-prod.yaml
@@ -11,3 +11,6 @@ azure:
     saksbehandler: "2e9c63d8-322e-4c1f-b500-a0abb812761c" # 0000-GA-Dagpenger-Saksbehandler
 
 DP_BEHANDLING_SCOPE: "api://prod-gcp.teamdagpenger.dp-behandling/.default"
+PERSON_KONTO_REGISTER_SCOPE: "prod-gcp:okonomi:sokos-kontoregister-person"
+PDL_API_HOST: "pdl-api.prod-fss-pub.nais.io"
+PDL_API_SCOPE: "prod-fss:pdl:pdl-api"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,16 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val exposedVersion: String by project
+val pamGeographyVersion: String by project
+val pdlVersion: String by project
+val kotlinLoggingVersion: String by project
+val urnlibVersion: String by project
+val prometheusMetricsCoreVersion: String by project
+val openHtmlToPdfVersion: String by project
+val dagpengerOauth2KlientVersion: String by project
+
+val junitJupiterVersion: String by project
+val naisfulTestAppVersion: String by project
 
 plugins {
     kotlin("jvm") version "2.2.0"
@@ -51,25 +61,28 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
     implementation("org.jetbrains.exposed:exposed-java-time:$exposedVersion")
     implementation("org.jetbrains.exposed:exposed-json:$exposedVersion")
-    implementation("io.github.microutils:kotlin-logging:3.0.5")
-    implementation("de.slub-dresden:urnlib:2.0.1")
-    implementation("io.prometheus:prometheus-metrics-core:1.3.8")
-    implementation("io.github.openhtmltopdf:openhtmltopdf-pdfbox:1.1.28")
-    implementation("io.github.openhtmltopdf:openhtmltopdf-svg-support:1.1.28")
-    implementation("no.nav.dagpenger:oauth2-klient:2025.04.26-14.51.bbf9ece5f5ec")
+    implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+    implementation("de.slub-dresden:urnlib:$urnlibVersion")
+    implementation("io.prometheus:prometheus-metrics-core:$prometheusMetricsCoreVersion")
+    implementation("io.github.openhtmltopdf:openhtmltopdf-pdfbox:$openHtmlToPdfVersion")
+    implementation("io.github.openhtmltopdf:openhtmltopdf-svg-support:$openHtmlToPdfVersion")
+    implementation("no.nav.dagpenger:oauth2-klient:$dagpengerOauth2KlientVersion")
+    implementation("no.nav.pam.geography:pam-geography:$pamGeographyVersion")
+    implementation("no.nav.dagpenger:pdl-klient:$pdlVersion")
 
     implementation("io.ktor:ktor-server-netty:${libs.versions.ktor.get()}")
     implementation("io.ktor:ktor-server-config-yaml:${libs.versions.ktor.get()}")
 
     testImplementation(kotlin("test"))
+    testImplementation(libs.ktor.client.mock)
     testImplementation(libs.bundles.kotest.assertions)
     testImplementation(libs.mockk)
     testImplementation(libs.mock.oauth2.server)
     testImplementation(libs.bundles.postgres.test)
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.13.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion")
     testImplementation("io.ktor:ktor-server-test-host-jvm:${libs.versions.ktor.get()}")
     testImplementation(libs.rapids.and.rivers.test)
-    testImplementation("com.github.navikt.tbd-libs:naisful-test-app:2025.06.20-13.05-40af2647")
+    testImplementation("com.github.navikt.tbd-libs:naisful-test-app:$naisfulTestAppVersion")
 }
 
 tasks.withType<ShadowJar> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,11 @@
 exposedVersion=0.48.0
+pamGeographyVersion=2.21
+pdlVersion=2025.04.26-14.51.bbf9ece5f5ec
+kotlinLoggingVersion=3.0.5
+urnlibVersion=2.0.1
+prometheusMetricsCoreVersion=1.3.8
+openHtmlToPdfVersion=1.1.28
+dagpengerOauth2KlientVersion=2025.04.26-14.51.bbf9ece5f5ec
+
+junitJupiterVersion=5.13.2
+naisfulTestAppVersion=2025.06.20-13.05-40af2647

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/Configuration.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/Configuration.kt
@@ -18,11 +18,21 @@ internal object Configuration {
             mapOf(
                 "DP_BEHANDLING_BASE_URL" to "http://dp-behandling",
                 "DP_BEHANDLING_SCOPE" to "api://dev-gcp.teamdagpenger.dp-behandling/.default",
+                "PERSON_KONTO_REGISTER_URL" to "http://sokos-kontoregister-person.okonomi/api/borger/v1/hent-aktiv-konto",
             ),
         )
 
     val properties =
         ConfigurationProperties.systemProperties() overriding EnvironmentVariables() overriding defaultProperties
+
+    val pdlApiUrl by lazy {
+        properties[Key("PDL_API_HOST", stringType)].let {
+            "https://$it/graphql"
+        }
+    }
+    val pdlApiScope by lazy { properties[Key("PDL_API_SCOPE", stringType)] }
+    val personKontoRegisterUrl by lazy { properties[Key("PERSON_KONTO_REGISTER_URL", stringType)] }
+    val personKontoRegisterScope by lazy { properties[Key("PERSON_KONTO_REGISTER_SCOPE", stringType)] }
 
     val miljøVariabler =
         Variabler(
@@ -41,6 +51,23 @@ internal object Configuration {
             authType = azureAdConfig.clientSecret(),
         )
     }
+
+    val tokenXClient: CachedOauth2Client by lazy {
+        val tokenX = OAuth2Config.TokenX(properties)
+        CachedOauth2Client(
+            tokenEndpointUrl = tokenX.tokenEndpointUrl,
+            authType = tokenX.privateKey(),
+        )
+    }
+
+    fun tokenXClient(audience: String) =
+        { subjectToken: String ->
+            tokenXClient
+                .tokenExchange(
+                    token = subjectToken,
+                    audience = audience,
+                ).access_token ?: throw RuntimeException("Klarte ikke hente token")
+        }
 }
 
 data class Variabler(

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/AdresseDto.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/AdresseDto.kt
@@ -1,0 +1,11 @@
+package no.nav.dagpenger.soknad.orkestrator.personalia
+
+data class AdresseDto(
+    val adresselinje1: String = "",
+    val adresselinje2: String = "",
+    val adresselinje3: String = "",
+    val postnummer: String = "",
+    val poststed: String? = "",
+    val landkode: String = "",
+    val land: String = "",
+)

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/AdresseMapper.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/AdresseMapper.kt
@@ -1,0 +1,157 @@
+package no.nav.dagpenger.soknad.orkestrator.personalia
+
+import no.nav.dagpenger.pdl.adresse.AdresseMetadata
+import no.nav.dagpenger.pdl.adresse.PDLAdresse
+import no.nav.dagpenger.pdl.adresse.PostAdresseOrder
+import no.nav.dagpenger.soknad.orkestrator.personalia.PDLAdresseMapper.LandDataOppslag.finnLand
+import no.nav.dagpenger.soknad.orkestrator.personalia.PDLAdresseMapper.PostDataOppslag.finnPoststed
+import no.nav.dagpenger.soknad.orkestrator.personalia.PDLAdresseMapper.formatertAdresse
+import no.nav.pam.geography.Country
+import no.nav.pam.geography.CountryDAO
+import no.nav.pam.geography.PostDataDAO
+import java.io.IOException
+import kotlin.collections.filterNot
+import kotlin.collections.firstOrNull
+import kotlin.collections.getOrNull
+import kotlin.collections.joinToString
+import kotlin.collections.sortedWith
+
+class AdresseMapper(
+    pdlAdresser: List<PDLAdresse>,
+) {
+    val folkeregistertAdresse: AdresseDto?
+    val postAdresse: AdresseDto?
+
+    init {
+        val sortert = pdlAdresser.sortedWith(PostAdresseOrder.comparator)
+        folkeregistertAdresse =
+            sortert
+                .firstOrNull { it.adresseMetadata.adresseType == AdresseMetadata.AdresseType.BOSTEDSADRESSE }
+                ?.let(::formatertAdresse)
+
+        postAdresse = sortert.firstOrNull()?.let(::formatertAdresse)
+    }
+}
+
+@Suppress("DuplicatedCode")
+internal object PDLAdresseMapper : no.nav.dagpenger.pdl.adresse.AdresseMapper<AdresseDto>() {
+    private class GeografiOppslagInitException(
+        e: Exception,
+    ) : RuntimeException(e)
+
+    private object PostDataOppslag {
+        private val dao: PostDataDAO =
+            try {
+                PostDataDAO()
+            } catch (e: IOException) {
+                throw GeografiOppslagInitException(e)
+            }
+
+        fun finnPoststed(postNummer: String?): String? =
+            postNummer?.let {
+                dao.findPostData(postNummer).map { it.capitalizedCityName }.orElse(null)
+            }
+    }
+
+    private object LandDataOppslag {
+        private val dao: CountryDAO =
+            try {
+                CountryDAO()
+            } catch (e: IOException) {
+                throw GeografiOppslagInitException(e)
+            }
+
+        fun finnLand(landKode: String?): Country? = landKode?.let { dao.findCountryByCode(it).orElse(null) }
+    }
+
+    override fun formatertAdresse(pdlAdresse: PDLAdresse.MatrikkelAdresse): AdresseDto = AdresseDto()
+
+    override fun formatertAdresse(pdlAdresse: PDLAdresse.PostAdresseIFrittFormat): AdresseDto {
+        with(pdlAdresse) {
+            val adresseLinjer = listOf(adresseLinje1, adresseLinje2, adresseLinje3).filterNot(String?::isNullOrBlank)
+
+            return AdresseDto(
+                adresselinje1 = adresseLinjer.getOrNull(0) ?: "",
+                adresselinje2 = adresseLinjer.getOrNull(1) ?: "",
+                adresselinje3 = adresseLinjer.getOrNull(2) ?: "",
+                postnummer = postnummer ?: "",
+                poststed = finnPoststed(postnummer) ?: "",
+                landkode = "NO",
+                land = "NORGE",
+            )
+        }
+    }
+
+    override fun formatertAdresse(pdlAdresse: PDLAdresse.PostboksAdresse): AdresseDto {
+        with(pdlAdresse) {
+            val adresseLinjer = listOf(postbokseier, postboks).filterNot(String?::isNullOrBlank)
+            return AdresseDto(
+                adresselinje1 = adresseLinjer.getOrNull(0) ?: "",
+                adresselinje2 = adresseLinjer.getOrNull(1) ?: "",
+                adresselinje3 = "",
+                postnummer = postnummer ?: "",
+                poststed = finnPoststed(postnummer) ?: "",
+                landkode = "NO",
+                land = "NORGE",
+            )
+        }
+    }
+
+    override fun formatertAdresse(pdlAdresse: PDLAdresse.TomAdresse): AdresseDto = AdresseDto()
+
+    override fun formatertAdresse(pdlAdresse: PDLAdresse.UtenlandsAdresseIFrittFormat): AdresseDto {
+        with(pdlAdresse) {
+            val adresseLinjer = listOf(adresseLinje1, adresseLinje2, adresseLinje3).filterNot(String?::isNullOrBlank)
+
+            val land = finnLand(landKode)
+            return AdresseDto(
+                adresselinje1 = adresseLinjer.getOrNull(0) ?: "",
+                adresselinje2 = adresseLinjer.getOrNull(1) ?: "",
+                adresselinje3 = adresseLinjer.getOrNull(2) ?: "",
+                postnummer = postkode ?: "",
+                poststed = byEllerStedsnavn ?: "",
+                landkode = land?.alpha2Code ?: "",
+                land = land?.name ?: "",
+            )
+        }
+    }
+
+    override fun formatertAdresse(pdlAdresse: PDLAdresse.UtenlandskAdresse): AdresseDto {
+        with(pdlAdresse) {
+            val adresseLinjer =
+                listOf(adressenavnNummer, bygningEtasjeLeilighet, postboksNummerNavn).filterNot(String?::isNullOrBlank)
+
+            val land = finnLand(landKode)
+            return AdresseDto(
+                adresselinje1 = adresseLinjer.getOrNull(0) ?: "",
+                adresselinje2 = adresseLinjer.getOrNull(1) ?: "",
+                adresselinje3 = adresseLinjer.getOrNull(2) ?: "",
+                postnummer = postkode ?: "",
+                poststed = bySted ?: "",
+                landkode = land?.alpha2Code ?: "",
+                land = land?.name ?: "",
+            )
+        }
+    }
+
+    override fun formatertAdresse(pdlAdresse: PDLAdresse.VegAdresse): AdresseDto {
+        val husNummerBokstav =
+            listOf(pdlAdresse.husnummer, pdlAdresse.husbokstav).filterNot(String?::isNullOrBlank).joinToString("")
+
+        val adresselinje2 =
+            listOf(pdlAdresse.adressenavn, husNummerBokstav)
+                .filterNot(String?::isNullOrBlank)
+                .joinToString(separator = " ")
+
+        val adresseLinjer = listOf(pdlAdresse.adresseMetadata.coAdresseNavn, adresselinje2).filterNot(String?::isNullOrBlank)
+
+        return AdresseDto(
+            adresselinje1 = adresseLinjer.getOrNull(0) ?: "",
+            adresselinje2 = adresseLinjer.getOrNull(1) ?: "",
+            postnummer = pdlAdresse.postnummer ?: "",
+            poststed = finnPoststed(pdlAdresse.postnummer) ?: "",
+            landkode = "NO",
+            land = "NORGE",
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/KontonummerDto.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/KontonummerDto.kt
@@ -1,0 +1,11 @@
+package no.nav.dagpenger.soknad.orkestrator.personalia
+
+data class KontonummerDto(
+    val kontonummer: String? = null,
+    val banknavn: String? = null,
+    val bankLandkode: String? = null,
+) {
+    companion object {
+        val TOM = KontonummerDto()
+    }
+}

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/KontonummerService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/KontonummerService.kt
@@ -1,0 +1,85 @@
+package no.nav.dagpenger.soknad.orkestrator.personalia
+
+import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
+import com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.LogLevel.INFO
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders.Accept
+import io.ktor.http.HttpHeaders.Authorization
+import io.ktor.http.HttpStatusCode.Companion.NotFound
+import io.ktor.serialization.jackson.jackson
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+class KontonummerService(
+    private val kontoRegisterUrl: String,
+    private val tokenProvider: (subjectToken: String) -> String,
+    httpClientEngine: HttpClientEngine = CIO.create(),
+) {
+    private val kontoNummberClient =
+        HttpClient(httpClientEngine) {
+            expectSuccess = true
+            install(Logging) {
+                level = INFO
+            }
+            install(ContentNegotiation) {
+                jackson {
+                    registerModule(JavaTimeModule())
+                    configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+                    disable(WRITE_DATES_AS_TIMESTAMPS)
+                }
+            }
+        }
+
+    suspend fun hentKontonummer(subjectToken: String): KontonummerDto =
+        try {
+            kontoNummberClient
+                .get(kontoRegisterUrl) {
+                    header(Authorization, "Bearer ${tokenProvider.invoke(subjectToken)}")
+                    header(Accept, "application/json")
+                }.body<KontoNummerRespsonse>()
+                .let { map(it) }
+        } catch (e: ClientRequestException) {
+            if (e.response.status == NotFound) {
+                logger.warn("Kontonummer ikke funnet for bruker")
+            } else {
+                logger.warn("Kall mot $kontoRegisterUrl feilet med klientfeil \"${e.response.status} ${e.response.bodyAsText()}\".", e)
+            }
+            KontonummerDto.TOM
+        }
+
+    private fun map(response: KontoNummerRespsonse): KontonummerDto =
+        if (!response.kontonummer.isNullOrBlank()) {
+            KontonummerDto(kontonummer = response.kontonummer)
+        } else if (response.utenlandskKontoInfo != null) {
+            KontonummerDto(
+                kontonummer = response.utenlandskKontoInfo.bankkode,
+                banknavn = response.utenlandskKontoInfo.banknavn,
+                bankLandkode = response.utenlandskKontoInfo.bankLandkode,
+            )
+        } else {
+            KontonummerDto.TOM
+        }
+
+    private data class KontoNummerRespsonse(
+        val kontonummer: String? = null,
+        val utenlandskKontoInfo: UtenlandskKontoInfoResponse? = null,
+    ) {
+        data class UtenlandskKontoInfoResponse(
+            val banknavn: String? = null,
+            val bankkode: String? = null,
+            val bankLandkode: String? = null,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/PersonDto.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/PersonDto.kt
@@ -1,0 +1,13 @@
+package no.nav.dagpenger.soknad.orkestrator.personalia
+
+import java.time.LocalDate
+
+data class PersonDto(
+    val fornavn: String = "",
+    val mellomnavn: String = "",
+    val etternavn: String = "",
+    val fodselsDato: LocalDate,
+    val ident: String,
+    val postAdresse: AdresseDto?,
+    val folkeregistrertAdresse: AdresseDto?,
+)

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/PersonService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/PersonService.kt
@@ -1,0 +1,37 @@
+package no.nav.dagpenger.soknad.orkestrator.personalia
+
+import io.ktor.http.HttpHeaders.Authorization
+import no.nav.dagpenger.pdl.PersonOppslag
+import no.nav.dagpenger.pdl.adresse.AdresseVisitor
+
+class PersonService(
+    private val personOppslag: PersonOppslag,
+    private val tokenProvider: (subjectToken: String) -> String,
+) {
+    suspend fun hentPerson(
+        fnr: String,
+        subjectToken: String,
+    ): PersonDto {
+        val person =
+            personOppslag.hentPerson(
+                fnr,
+                mapOf(
+                    Authorization to "Bearer ${tokenProvider.invoke(subjectToken)}",
+                    // TODO: Skal denne endres (kopiert fra dp-soknad)?
+                    "behandlingsnummer" to "B286",
+                ),
+            )
+
+        val adresseMapper = AdresseMapper(AdresseVisitor(person).adresser)
+
+        return PersonDto(
+            fornavn = person.fornavn,
+            mellomnavn = person.mellomnavn ?: "",
+            etternavn = person.etternavn,
+            fodselsDato = person.fodselsdato,
+            ident = person.fodselnummer,
+            postAdresse = adresseMapper.postAdresse,
+            folkeregistrertAdresse = adresseMapper.folkeregistertAdresse,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/PersonaliaApi.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/PersonaliaApi.kt
@@ -1,0 +1,24 @@
+package no.nav.dagpenger.soknad.orkestrator.personalia
+
+import io.ktor.server.application.Application
+import io.ktor.server.auth.authenticate
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import no.nav.dagpenger.soknad.orkestrator.api.auth.ident
+import no.nav.dagpenger.soknad.orkestrator.api.auth.jwt
+
+internal fun Application.personaliaApi(personaliaService: PersonaliaService) {
+    routing {
+        authenticate("tokenX") {
+            route("/personalia") {
+                get {
+                    call.respond(
+                        personaliaService.getPersonalia(call.ident(), call.request.jwt()),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/PersonaliaDto.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/PersonaliaDto.kt
@@ -1,0 +1,6 @@
+package no.nav.dagpenger.soknad.orkestrator.personalia
+
+data class PersonaliaDto(
+    val person: PersonDto,
+    val kontonummer: String?,
+)

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/PersonaliaService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/PersonaliaService.kt
@@ -1,0 +1,15 @@
+package no.nav.dagpenger.soknad.orkestrator.personalia
+
+class PersonaliaService(
+    val personService: PersonService,
+    val kontonummerService: KontonummerService,
+) {
+    suspend fun getPersonalia(
+        fnr: String,
+        subjectToken: String,
+    ): PersonaliaDto =
+        PersonaliaDto(
+            person = personService.hentPerson(fnr, subjectToken),
+            kontonummer = kontonummerService.hentKontonummer(subjectToken).kontonummer,
+        )
+}

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/AdresseMapperTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/AdresseMapperTest.kt
@@ -1,0 +1,376 @@
+package no.nav.dagpenger.soknad.orkestrator.personalia
+
+import io.kotest.matchers.shouldBe
+import no.nav.dagpenger.pdl.adresse.AdresseMetadata
+import no.nav.dagpenger.pdl.adresse.AdresseMetadata.AdresseType
+import no.nav.dagpenger.pdl.adresse.AdresseMetadata.AdresseType.BOSTEDSADRESSE
+import no.nav.dagpenger.pdl.adresse.AdresseMetadata.AdresseType.KONTAKTADRESSE
+import no.nav.dagpenger.pdl.adresse.AdresseMetadata.AdresseType.OPPHOLDSADRESSE
+import no.nav.dagpenger.pdl.adresse.AdresseMetadata.MasterType
+import no.nav.dagpenger.pdl.adresse.PDLAdresse
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class AdresseMapperTest {
+    @Test
+    fun `AdresseMapper bruker BOSTEDSADRESSE som folkeregistrert adresse`() {
+        val pdlAdresses =
+            listOf(
+                createPdlAdresse(OPPHOLDSADRESSE, "2000"),
+                createPdlAdresse(BOSTEDSADRESSE, "2001"),
+                createPdlAdresse(KONTAKTADRESSE, "2002"),
+            )
+
+        AdresseMapper(pdlAdresses).folkeregistertAdresse?.postnummer shouldBe "2001"
+    }
+
+    @Test
+    fun `AdresseMapper returnerer null som folkeregistrert adresse hvis input er tom liste`() {
+        AdresseMapper(emptyList()).folkeregistertAdresse shouldBe null
+    }
+
+    @Test
+    fun `AdresseMapper returnerer null som postadresse adresse hvis input er tom liste`() {
+        AdresseMapper(emptyList()).postAdresse shouldBe null
+    }
+
+    @Test
+    fun `AdresseMapper returnerer null som folkeregistrert adresse hvis input ikke inneholder BOSTEDSADRESSE`() {
+        AdresseMapper(
+            listOf(
+                createPdlAdresse(OPPHOLDSADRESSE, "2000"),
+                createPdlAdresse(KONTAKTADRESSE, "2001"),
+            ),
+        ).folkeregistertAdresse shouldBe null
+    }
+
+    @Test
+    fun `AdresseMapper bruker KONTAKTADRESSE som postadresse hvis den eksisterer`() {
+        val pdlAdresses =
+            listOf(
+                createPdlAdresse(OPPHOLDSADRESSE, "2000"),
+                createPdlAdresse(BOSTEDSADRESSE, "2001"),
+                createPdlAdresse(KONTAKTADRESSE, "2002"),
+            )
+
+        AdresseMapper(pdlAdresses).postAdresse?.postnummer shouldBe "2002"
+    }
+
+    @Test
+    fun `AdresseMapper bruker OPPHOLDSADRESSE som postadresse hvis den eksisterer og KONTAKTADRESSE ikke eksisterer`() {
+        val pdlAdresses =
+            listOf(
+                createPdlAdresse(OPPHOLDSADRESSE, "2000"),
+                createPdlAdresse(BOSTEDSADRESSE, "2001"),
+            )
+
+        AdresseMapper(pdlAdresses).postAdresse?.postnummer shouldBe "2000"
+    }
+
+    @Test
+    fun `AdresseMapper bruker BOSTEDSADRESSE som postadresse hvis det er den eneste adressen som eksisterer`() {
+        val pdlAdresses =
+            listOf(
+                createPdlAdresse(BOSTEDSADRESSE, "2001"),
+            )
+
+        AdresseMapper(pdlAdresses).postAdresse?.postnummer shouldBe "2001"
+    }
+
+    @Test
+    fun `AdresseMapper mapper PDLAdresse_PostAdresseIFrittFormat til forventede verdier hvis PDL returnerer adresse med verdier`() {
+        val pdflAdresse =
+            PDLAdresse.PostAdresseIFrittFormat(
+                adresseMetadata =
+                    AdresseMetadata(
+                        adresseType = BOSTEDSADRESSE,
+                        master = MasterType.PDL,
+                    ),
+                adresseLinje1 = "adr1",
+                adresseLinje2 = "adr2",
+                adresseLinje3 = "adr3",
+                postnummer = "1453",
+            )
+
+        val adresseMapper = AdresseMapper(listOf(pdflAdresse))
+
+        adresseMapper.postAdresse?.adresselinje1 shouldBe "adr1"
+        adresseMapper.postAdresse?.adresselinje2 shouldBe "adr2"
+        adresseMapper.postAdresse?.adresselinje3 shouldBe "adr3"
+        adresseMapper.postAdresse?.postnummer shouldBe "1453"
+        adresseMapper.postAdresse?.poststed shouldBe "Bjørnemyr"
+        adresseMapper.postAdresse?.landkode shouldBe "NO"
+        adresseMapper.postAdresse?.land shouldBe "NORGE"
+    }
+
+    @Test
+    fun `AdresseMapper mapper PDLAdresse_PostAdresseIFrittFormat til forventede verdier hvis PDL returnerer adresse uten verdier`() {
+        val pdflAdresse =
+            PDLAdresse.PostAdresseIFrittFormat(
+                adresseMetadata =
+                    AdresseMetadata(
+                        adresseType = BOSTEDSADRESSE,
+                        master = MasterType.PDL,
+                    ),
+                adresseLinje1 = null,
+                adresseLinje2 = null,
+                adresseLinje3 = null,
+                postnummer = null,
+            )
+
+        val adresseMapper = AdresseMapper(listOf(pdflAdresse))
+
+        adresseMapper.postAdresse?.adresselinje1 shouldBe ""
+        adresseMapper.postAdresse?.adresselinje2 shouldBe ""
+        adresseMapper.postAdresse?.adresselinje3 shouldBe ""
+        adresseMapper.postAdresse?.postnummer shouldBe ""
+        adresseMapper.postAdresse?.poststed shouldBe ""
+        adresseMapper.postAdresse?.landkode shouldBe "NO"
+        adresseMapper.postAdresse?.land shouldBe "NORGE"
+    }
+
+    @Test
+    fun `AdresseMapper mapper PDLAdresse_PostboksAdresse til forventede verdier hvis PDL returnerer adresse med verdier`() {
+        val pdflAdresse =
+            PDLAdresse.PostboksAdresse(
+                adresseMetadata =
+                    AdresseMetadata(
+                        adresseType = BOSTEDSADRESSE,
+                        master = MasterType.PDL,
+                    ),
+                postbokseier = "postbokseier",
+                postboks = "postboks",
+                postnummer = "1453",
+            )
+
+        val adresseMapper = AdresseMapper(listOf(pdflAdresse))
+
+        adresseMapper.postAdresse?.adresselinje1 shouldBe "postbokseier"
+        adresseMapper.postAdresse?.adresselinje2 shouldBe "postboks"
+        adresseMapper.postAdresse?.adresselinje3 shouldBe ""
+        adresseMapper.postAdresse?.postnummer shouldBe "1453"
+        adresseMapper.postAdresse?.poststed shouldBe "Bjørnemyr"
+        adresseMapper.postAdresse?.landkode shouldBe "NO"
+        adresseMapper.postAdresse?.land shouldBe "NORGE"
+    }
+
+    @Test
+    fun `AdresseMapper mapper PDLAdresse_PostboksAdresse til forventede verdier hvis PDL returnerer adresse uten verdier`() {
+        val pdflAdresse =
+            PDLAdresse.PostboksAdresse(
+                adresseMetadata =
+                    AdresseMetadata(
+                        adresseType = BOSTEDSADRESSE,
+                        master = MasterType.PDL,
+                    ),
+                postbokseier = null,
+                postboks = null,
+                postnummer = null,
+            )
+
+        val adresseMapper = AdresseMapper(listOf(pdflAdresse))
+
+        adresseMapper.postAdresse?.adresselinje1 shouldBe ""
+        adresseMapper.postAdresse?.adresselinje2 shouldBe ""
+        adresseMapper.postAdresse?.adresselinje3 shouldBe ""
+        adresseMapper.postAdresse?.postnummer shouldBe ""
+        adresseMapper.postAdresse?.poststed shouldBe ""
+        adresseMapper.postAdresse?.landkode shouldBe "NO"
+        adresseMapper.postAdresse?.land shouldBe "NORGE"
+    }
+
+    @Test
+    fun `AdresseMapper mapper PDLAdresse_UtenlandsAdresseIFrittFormat til forventede verdier hvis PDL returnerer adresse med verdier`() {
+        val pdflAdresse =
+            PDLAdresse.UtenlandsAdresseIFrittFormat(
+                adresseMetadata =
+                    AdresseMetadata(
+                        adresseType = BOSTEDSADRESSE,
+                        master = MasterType.PDL,
+                    ),
+                adresseLinje1 = "adr1",
+                adresseLinje2 = "adr2",
+                adresseLinje3 = "adr3",
+                postkode = "N12-W4",
+                byEllerStedsnavn = "byEllerStedsnavn",
+                landKode = "SE",
+            )
+
+        val adresseMapper = AdresseMapper(listOf(pdflAdresse))
+
+        adresseMapper.postAdresse?.adresselinje1 shouldBe "adr1"
+        adresseMapper.postAdresse?.adresselinje2 shouldBe "adr2"
+        adresseMapper.postAdresse?.adresselinje3 shouldBe "adr3"
+        adresseMapper.postAdresse?.postnummer shouldBe "N12-W4"
+        adresseMapper.postAdresse?.poststed shouldBe "byEllerStedsnavn"
+        adresseMapper.postAdresse?.landkode shouldBe "SE"
+        adresseMapper.postAdresse?.land shouldBe "SVERIGE"
+    }
+
+    @Test
+    fun `AdresseMapper mapper PDLAdresse_UtenlandsAdresseIFrittFormat til forventede verdier hvis PDL returnerer adresse uten verdier`() {
+        val pdflAdresse =
+            PDLAdresse.UtenlandsAdresseIFrittFormat(
+                adresseMetadata =
+                    AdresseMetadata(
+                        adresseType = BOSTEDSADRESSE,
+                        master = MasterType.PDL,
+                    ),
+                adresseLinje1 = null,
+                adresseLinje2 = null,
+                adresseLinje3 = null,
+                postkode = null,
+                byEllerStedsnavn = null,
+                landKode = null,
+            )
+
+        val adresseMapper = AdresseMapper(listOf(pdflAdresse))
+
+        adresseMapper.postAdresse?.adresselinje1 shouldBe ""
+        adresseMapper.postAdresse?.adresselinje2 shouldBe ""
+        adresseMapper.postAdresse?.adresselinje3 shouldBe ""
+        adresseMapper.postAdresse?.postnummer shouldBe ""
+        adresseMapper.postAdresse?.poststed shouldBe ""
+        adresseMapper.postAdresse?.landkode shouldBe ""
+        adresseMapper.postAdresse?.land shouldBe ""
+    }
+
+    @Test
+    fun `AdresseMapper mapper PDLAdresse_UtenlandskAdresse til forventede verdier hvis PDL returnerer adresse med verdier`() {
+        val pdflAdresse =
+            PDLAdresse.UtenlandskAdresse(
+                adresseMetadata =
+                    AdresseMetadata(
+                        adresseType = BOSTEDSADRESSE,
+                        master = MasterType.PDL,
+                    ),
+                adressenavnNummer = "adressenavnNummer",
+                bygningEtasjeLeilighet = "bygningEtasjeLeilighet",
+                postboksNummerNavn = "postboksNummerNavn",
+                postkode = "N12-W4",
+                bySted = "bySted",
+                landKode = "DK",
+            )
+
+        val adresseMapper = AdresseMapper(listOf(pdflAdresse))
+
+        adresseMapper.postAdresse?.adresselinje1 shouldBe "adressenavnNummer"
+        adresseMapper.postAdresse?.adresselinje2 shouldBe "bygningEtasjeLeilighet"
+        adresseMapper.postAdresse?.adresselinje3 shouldBe "postboksNummerNavn"
+        adresseMapper.postAdresse?.postnummer shouldBe "N12-W4"
+        adresseMapper.postAdresse?.poststed shouldBe "bySted"
+        adresseMapper.postAdresse?.landkode shouldBe "DK"
+        adresseMapper.postAdresse?.land shouldBe "DANMARK"
+    }
+
+    @Test
+    fun `AdresseMapper mapper PDLAdresse_UtenlandskAdresse til forventede verdier hvis PDL returnerer adresse uten verdier`() {
+        val pdflAdresse =
+            PDLAdresse.UtenlandskAdresse(
+                adresseMetadata =
+                    AdresseMetadata(
+                        adresseType = BOSTEDSADRESSE,
+                        master = MasterType.PDL,
+                    ),
+                adressenavnNummer = null,
+                bygningEtasjeLeilighet = null,
+                postboksNummerNavn = null,
+                postkode = null,
+                bySted = null,
+                landKode = null,
+            )
+
+        val adresseMapper = AdresseMapper(listOf(pdflAdresse))
+
+        adresseMapper.postAdresse?.adresselinje1 shouldBe ""
+        adresseMapper.postAdresse?.adresselinje2 shouldBe ""
+        adresseMapper.postAdresse?.adresselinje3 shouldBe ""
+        adresseMapper.postAdresse?.postnummer shouldBe ""
+        adresseMapper.postAdresse?.poststed shouldBe ""
+        adresseMapper.postAdresse?.landkode shouldBe ""
+        adresseMapper.postAdresse?.land shouldBe ""
+    }
+
+    @Test
+    fun `AdresseMapper mapper PDLAdresse_VegAdresse til forventede verdier hvis PDL returnerer adresse med verdier`() {
+        val pdflAdresse =
+            PDLAdresse.VegAdresse(
+                adresseMetadata =
+                    AdresseMetadata(
+                        coAdresseNavn = "coAdresseNavn",
+                        adresseType = BOSTEDSADRESSE,
+                        master = MasterType.PDL,
+                    ),
+                husnummer = "husnummer",
+                husbokstav = "husbokstav",
+                adressenavn = "adressenavn",
+                postnummer = "1453",
+            )
+
+        val adresseMapper = AdresseMapper(listOf(pdflAdresse))
+
+        adresseMapper.postAdresse?.adresselinje1 shouldBe "coAdresseNavn"
+        adresseMapper.postAdresse?.adresselinje2 shouldBe "adressenavn husnummerhusbokstav"
+        adresseMapper.postAdresse?.postnummer shouldBe "1453"
+        adresseMapper.postAdresse?.poststed shouldBe "Bjørnemyr"
+        adresseMapper.postAdresse?.landkode shouldBe "NO"
+        adresseMapper.postAdresse?.land shouldBe "NORGE"
+    }
+
+    @Test
+    fun `AdresseMapper mapper PDLAdresse_VegAdresse til forventede verdier hvis PDL returnerer adresse uten verdier`() {
+        val pdflAdresse =
+            PDLAdresse.VegAdresse(
+                adresseMetadata =
+                    AdresseMetadata(
+                        coAdresseNavn = null,
+                        adresseType = BOSTEDSADRESSE,
+                        master = MasterType.PDL,
+                    ),
+                husnummer = null,
+                husbokstav = null,
+                adressenavn = null,
+                postnummer = null,
+            )
+
+        val adresseMapper = AdresseMapper(listOf(pdflAdresse))
+
+        adresseMapper.postAdresse?.adresselinje1 shouldBe ""
+        adresseMapper.postAdresse?.adresselinje2 shouldBe ""
+        adresseMapper.postAdresse?.postnummer shouldBe ""
+        adresseMapper.postAdresse?.poststed shouldBe ""
+        adresseMapper.postAdresse?.landkode shouldBe "NO"
+        adresseMapper.postAdresse?.land shouldBe "NORGE"
+    }
+
+    @Test
+    fun `AdresseMapper mapper PDLAdresse_TomAdresse til forventede verdier`() {
+        AdresseMapper(listOf(PDLAdresse.TomAdresse)).postAdresse shouldBe AdresseDto()
+    }
+
+    @Test
+    fun `AdresseMapper mapper PDLAdresse_MatrikkelAdresse til forventede verdier`() {
+        val pdlAdresse =
+            PDLAdresse.MatrikkelAdresse(
+                adresseMetadata =
+                    AdresseMetadata(adresseType = BOSTEDSADRESSE, master = MasterType.PDL),
+            )
+
+        AdresseMapper(listOf(pdlAdresse)).postAdresse shouldBe AdresseDto()
+    }
+
+    private fun createPdlAdresse(
+        adresseType: AdresseType,
+        postnummer: String,
+        gyldigFom: LocalDate? = LocalDate.now(),
+    ): PDLAdresse =
+        PDLAdresse.PostboksAdresse(
+            adresseMetadata =
+                AdresseMetadata(
+                    gyldigFom = gyldigFom,
+                    adresseType = adresseType,
+                    master = MasterType.PDL,
+                ),
+            postnummer = postnummer,
+        )
+}

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/KontonummerServiceTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/KontonummerServiceTest.kt
@@ -1,0 +1,111 @@
+package no.nav.dagpenger.soknad.orkestrator.personalia
+
+import io.kotest.matchers.shouldBe
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode.Companion.NotFound
+import io.ktor.http.HttpStatusCode.Companion.OK
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import no.nav.dagpenger.soknad.orkestrator.personalia.KontonummerDto.Companion.TOM
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+internal class KontonummerServiceTest {
+    @Test
+    fun `hentKontonummer returnerer forventet respons hvis kontoNumberClient returnerer 404 Not Found`() {
+        val kontonummerService =
+            KontonummerService(
+                kontoRegisterUrl = "http://localhost",
+                tokenProvider = { "token" },
+                httpClientEngine =
+                    MockEngine {
+                        respondError(NotFound)
+                    },
+            )
+        runBlocking {
+            kontonummerService.hentKontonummer("") shouldBe TOM
+        }
+    }
+
+    @Test
+    fun `hentKontonummer returnerer foreventet respons hvis kontoNumberClient returnerer norsk kontonummer`() {
+        val kontonummerService =
+            KontonummerService(
+                kontoRegisterUrl = "http://localhost",
+                tokenProvider = { subjektToken -> "token $subjektToken" },
+                httpClientEngine =
+                    MockEngine { request ->
+                        respond(
+                            content = norskKontoResponse,
+                            status = OK,
+                            headers =
+                                headersOf(
+                                    name = HttpHeaders.ContentType,
+                                    value = ContentType.Application.Json.toString(),
+                                ),
+                        )
+                    },
+            )
+        runBlocking {
+            kontonummerService.hentKontonummer(subjectToken = "norskKonto") shouldBe KontonummerDto(kontonummer = "123")
+        }
+    }
+
+    @Test
+    fun `hentKontonummer returnerer foreventet respons hvis kontoNumberClient returnerer utenlandsk kontonummer`() {
+        val service =
+            KontonummerService(
+                kontoRegisterUrl = "http://localhost",
+                tokenProvider = { subjektToken -> "token $subjektToken" },
+                httpClientEngine =
+                    MockEngine { request ->
+                        respond(
+                            content = utenlandskKontoResponse,
+                            status = OK,
+                            headers =
+                                headersOf(
+                                    name = HttpHeaders.ContentType,
+                                    value = ContentType.Application.Json.toString(),
+                                ),
+                        )
+                    },
+            )
+        runBlocking {
+            service.hentKontonummer(subjectToken = "utenlandsKkonto") shouldBe
+                KontonummerDto(
+                    kontonummer = "456",
+                    banknavn = "banknavn",
+                    bankLandkode = "SE",
+                )
+        }
+    }
+
+    @Language("JSON")
+    private val utenlandskKontoResponse =
+        """
+        {
+          "utenlandskKontoInfo": {
+            "banknavn": "banknavn",
+            "bankkode": "456",
+            "bankLandkode": "SE",
+            "valutakode": "SEK",
+            "swiftBicKode": "SHEDNO22",
+            "bankadresse1": "string",
+            "bankadresse2": "string",
+            "bankadresse3": "string"
+          }
+        }
+        """.trimIndent()
+
+    @Language("JSON")
+    private val norskKontoResponse =
+        """
+        {
+          "kontonummer": "123"
+        }
+        """.trimIndent()
+}

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/PersonServiceTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/PersonServiceTest.kt
@@ -1,0 +1,36 @@
+package no.nav.dagpenger.soknad.orkestrator.personalia
+
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.dagpenger.pdl.PDLPerson
+import no.nav.dagpenger.pdl.PersonOppslag
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class PersonServiceTest {
+    @Test
+    fun `hentPerson returnerer forventet respons hvis PDL returnerer en person`() {
+        val personOppslag = mockk<PersonOppslag>()
+        val personService = PersonService(personOppslag, { "token" })
+        val pdlPerson = mockk<PDLPerson>(relaxed = true)
+        every { pdlPerson.fornavn } returns "OLA"
+        every { pdlPerson.mellomnavn } returns "PETTER"
+        every { pdlPerson.etternavn } returns "DUNK"
+        every { pdlPerson.fodselsdato } returns LocalDate.of(2020, 1, 1)
+        every { pdlPerson.fodselnummer } returns "30212018224"
+        coEvery { personOppslag.hentPerson(any(), any()) } returns pdlPerson
+
+        runBlocking {
+            val person = personService.hentPerson("27279320064", "subjectToken")
+
+            person.fornavn shouldBe "OLA"
+            person.mellomnavn shouldBe "PETTER"
+            person.etternavn shouldBe "DUNK"
+            person.fodselsDato shouldBe LocalDate.of(2020, 1, 1)
+            person.ident shouldBe "30212018224"
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/PersonaliaApiTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/PersonaliaApiTest.kt
@@ -1,0 +1,69 @@
+package no.nav.dagpenger.soknad.orkestrator.personalia
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode.Companion.OK
+import io.ktor.http.HttpStatusCode.Companion.Unauthorized
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.jwt.jwt
+import io.mockk.coEvery
+import io.mockk.mockk
+import no.nav.dagpenger.soknad.orkestrator.api.auth.AuthFactory.tokenX
+import no.nav.dagpenger.soknad.orkestrator.utils.TestApplication.testTokenXToken
+import no.nav.dagpenger.soknad.orkestrator.utils.TestApplication.withMockAuthServerAndTestApplication
+import org.junit.jupiter.api.Test
+import java.time.LocalDate.now
+
+class PersonaliaApiTest {
+    val personaliaService = mockk<PersonaliaService>(relaxed = true)
+    val testModuleFunction: Application.() -> Unit = {
+        install(plugin = Authentication) {
+            jwt(name = "tokenX") {
+                tokenX()
+            }
+        }
+        personaliaApi(personaliaService)
+    }
+
+    @Test
+    fun `GET personalia returnerer 401 Unauthorized hvis klient ikke er autentisert`() {
+        withMockAuthServerAndTestApplication(moduleFunction = testModuleFunction) {
+            client.get(urlString = "/personalia").status shouldBe Unauthorized
+        }
+    }
+
+    @Test
+    fun `GET personalia returnerer 200 OK med forventet body hvis klient er autentisert`() {
+        coEvery { personaliaService.getPersonalia(fnr = any(), subjectToken = any()) } returns
+            PersonaliaDto(
+                PersonDto(
+                    fornavn = "",
+                    mellomnavn = "",
+                    etternavn = "",
+                    fodselsDato = now(),
+                    ident = "",
+                    postAdresse = null,
+                    folkeregistrertAdresse = null,
+                ),
+                kontonummer = null,
+            )
+
+        withMockAuthServerAndTestApplication(moduleFunction = testModuleFunction) {
+            val response =
+                client
+                    .get(urlString = "/personalia") {
+                        header(HttpHeaders.Authorization, "Bearer $testTokenXToken")
+                    }
+
+            response.status shouldBe OK
+            response.body() as PersonaliaDto shouldNotBe null
+            response.headers["Content-Type"] shouldBe "application/json; charset=UTF-8"
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/PersonaliaServiceTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/PersonaliaServiceTest.kt
@@ -1,0 +1,49 @@
+package no.nav.dagpenger.soknad.orkestrator.personalia
+
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.LocalDate.now
+
+class PersonaliaServiceTest {
+    @Test
+    fun `getPersonalia returnerer forventet respons`() {
+        val personService = mockk<PersonService>()
+        val kontonummerService = mockk<KontonummerService>()
+        val personaliaService = PersonaliaService(personService, kontonummerService)
+        val personDto = createPersonDto()
+        coEvery { personService.hentPerson(any(), any()) } returns personDto
+        coEvery { kontonummerService.hentKontonummer(any()) } returns KontonummerDto("51823888914")
+
+        runBlocking {
+            val personalia = personaliaService.getPersonalia("15230252251", "subjectToken")
+
+            personalia.person shouldBe personDto
+            personalia.kontonummer shouldBe "51823888914"
+        }
+    }
+
+    private fun createPersonDto(): PersonDto =
+        PersonDto(
+            fornavn = "fornavn",
+            mellomnavn = "mellomnavn",
+            etternavn = "etternavn",
+            fodselsDato = now(),
+            ident = "24302435967",
+            postAdresse = createAdresseDto("1234"),
+            folkeregistrertAdresse = createAdresseDto("1235"),
+        )
+
+    private fun createAdresseDto(postnummer: String): AdresseDto =
+        AdresseDto(
+            adresselinje1 = "adr1",
+            adresselinje2 = "adr2",
+            adresselinje3 = "adr3",
+            postnummer = postnummer,
+            poststed = "poststed",
+            landkode = "landkode",
+            land = "land",
+        )
+}


### PR DESCRIPTION
Henter ut personinformasjon fra PDL og kontoinformasjon fra sokos-kontoregister.

Mye gjenbruk av koden som brukes i dp-soknad, men med litt refaktorering og høyere testdekning.