### PR TITLE
Forhindre exceptions ved lagring av duplikat søknadbarnId

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/db/QuizOpplysningRepository.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/db/QuizOpplysningRepository.kt
@@ -27,10 +27,7 @@ interface QuizOpplysningRepository {
         oppdatertBarn: BarnSvar,
     )
 
-    fun lagreBarnSøknadMapping(
-        søknadId: UUID,
-        søknadbarnId: UUID,
-    )
+    fun lagreBarnSøknadMapping(søknadId: UUID): UUID
 
     fun hentEllerOpprettSøknadbarnId(søknadId: UUID): UUID
 

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/db/QuizOpplysningRepositoryPostgres.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/db/QuizOpplysningRepositoryPostgres.kt
@@ -38,7 +38,6 @@ import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.insertAndGetId
-import org.jetbrains.exposed.sql.insertIgnore
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
@@ -140,17 +139,7 @@ class QuizOpplysningRepositoryPostgres(
         }
     }
 
-    override fun lagreBarnSøknadMapping(
-        søknadId: UUID,
-        søknadbarnId: UUID,
-    ) {
-        transaction {
-            BarnSøknadMappingTabell.insertIgnore {
-                it[BarnSøknadMappingTabell.søknadId] = søknadId
-                it[BarnSøknadMappingTabell.søknadbarnId] = søknadbarnId
-            }
-        }
-    }
+    override fun lagreBarnSøknadMapping(søknadId: UUID) = hentEllerOpprettSøknadbarnId(søknadId)
 
     override fun hentEllerOpprettSøknadbarnId(søknadId: UUID): UUID =
         transaction {
@@ -163,7 +152,11 @@ class QuizOpplysningRepositoryPostgres(
 
             if (søknadbarnId == null) {
                 søknadbarnId = randomUUID()
-                lagreBarnSøknadMapping(søknadId, søknadbarnId)
+
+                BarnSøknadMappingTabell.insert {
+                    it[BarnSøknadMappingTabell.søknadId] = søknadId
+                    it[BarnSøknadMappingTabell.søknadbarnId] = søknadbarnId
+                }
             }
 
             søknadbarnId

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/db/SøknadRepository.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/db/SøknadRepository.kt
@@ -152,7 +152,6 @@ private fun opprettBarnSøknadMappingHvisBarnEksistererISøknaden(
     if (barnEksistererISøknad) {
         quizOpplysningRepository.lagreBarnSøknadMapping(
             søknadId = søknad.søknadId,
-            søknadbarnId = UUID.randomUUID(),
         )
     }
 }

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BarnetilleggBehovLøserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BarnetilleggBehovLøserTest.kt
@@ -27,7 +27,6 @@ class BarnetilleggBehovLøserTest {
     val behovløser = BarnetilleggBehovLøser(testRapid, quizOpplysningRepositorySpy)
     val ident = "12345678910"
     val søknadId: UUID = randomUUID()
-    val søknadbarnId: UUID = randomUUID()
 
     @Test
     fun `løser behov om barn hvis søknaden har barn`() {
@@ -87,7 +86,7 @@ class BarnetilleggBehovLøserTest {
             )
         opplysningRepository.lagre(pdlBarn)
         opplysningRepository.lagre(egetBarn)
-        opplysningRepository.lagreBarnSøknadMapping(søknadId = søknadId, søknadbarnId = søknadbarnId)
+        val lagretSøknadbarnId = opplysningRepository.lagreBarnSøknadMapping(søknadId = søknadId)
 
         behovløser.løs(lagBehovmelding(ident, søknadId, Barnetillegg))
 
@@ -95,7 +94,7 @@ class BarnetilleggBehovLøserTest {
         val løsteBarn = testRapid.inspektør.field(0, "@løsning")[Barnetillegg.name]["verdi"]
         løsteBarn.size() shouldBe 3
         løsteBarn[0].also {
-            it["søknadbarnId"].asUUID() shouldBe søknadbarnId
+            it["søknadbarnId"].asUUID() shouldBe lagretSøknadbarnId
             it["fornavnOgMellomnavn"].asText() shouldBe "Ola"
             it["etternavn"].asText() shouldBe "Nordmann"
             it["fødselsdato"].asText() shouldBe "2000-01-01"
@@ -107,7 +106,7 @@ class BarnetilleggBehovLøserTest {
             it["begrunnelse"].asText() shouldBe "Begrunnelse for endring"
         }
         løsteBarn[1].also {
-            it["søknadbarnId"].asUUID() shouldBe søknadbarnId
+            it["søknadbarnId"].asUUID() shouldBe lagretSøknadbarnId
             it["fornavnOgMellomnavn"].asText() shouldBe "Per"
             it["etternavn"].asText() shouldBe "Nordmann"
             it["fødselsdato"].asText() shouldBe "2000-01-01"
@@ -115,7 +114,7 @@ class BarnetilleggBehovLøserTest {
             it["kvalifiserer"].asBoolean() shouldBe false
         }
         løsteBarn[2].also {
-            it["søknadbarnId"].asUUID() shouldBe søknadbarnId
+            it["søknadbarnId"].asUUID() shouldBe lagretSøknadbarnId
             it["fornavnOgMellomnavn"].asText() shouldBe "Per"
             it["etternavn"].asText() shouldBe "Utland"
             it["fødselsdato"].asText() shouldBe "2000-01-01"

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BarnetilleggV2BehovLøserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BarnetilleggV2BehovLøserTest.kt
@@ -27,7 +27,6 @@ class BarnetilleggV2BehovLøserTest {
     val behovløser = BarnetilleggV2BehovLøser(testRapid, quizOpplysningRepositorySpy)
     val ident = "12345678910"
     val søknadId: UUID = randomUUID()
-    val søknadbarnId: UUID = randomUUID()
 
     @Test
     fun `løser behov om barn som forventet hvis søknaden har barn`() {
@@ -87,14 +86,14 @@ class BarnetilleggV2BehovLøserTest {
             )
         opplysningRepository.lagre(pdlBarn)
         opplysningRepository.lagre(egetBarn)
-        opplysningRepository.lagreBarnSøknadMapping(søknadId = søknadId, søknadbarnId = søknadbarnId)
+        val lagretSøknadbarnId = opplysningRepository.lagreBarnSøknadMapping(søknadId = søknadId)
 
         behovløser.løs(lagBehovmelding(ident, søknadId, BarnetilleggV2))
 
         val barnetilleggV2Løsning = testRapid.inspektør.field(0, "@løsning")[BarnetilleggV2.name]["verdi"]
         val løsteBarn = barnetilleggV2Løsning["barn"]
         verify(exactly = 1) { quizOpplysningRepositorySpy.hentEllerOpprettSøknadbarnId(any()) }
-        barnetilleggV2Løsning["søknadbarnId"].asUUID() shouldBe søknadbarnId
+        barnetilleggV2Løsning["søknadbarnId"].asUUID() shouldBe lagretSøknadbarnId
         løsteBarn.size() shouldBe 3
         løsteBarn[0].also {
             it["fornavnOgMellomnavn"].asText() shouldBe "Ola"

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/OpplysningApiTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/OpplysningApiTest.kt
@@ -115,7 +115,7 @@ class OpplysningApiTest {
             ),
         )
 
-        opplysningRepository.lagreBarnSøknadMapping(søknadId, søknadbarnId)
+        opplysningRepository.lagreBarnSøknadMapping(søknadId)
 
         withMockAuthServerAndTestApplication(moduleFunction = testModuleFunction) {
             client
@@ -167,7 +167,7 @@ class OpplysningApiTest {
             )
 
         opplysningRepository.lagre(opplysning)
-        opplysningRepository.lagreBarnSøknadMapping(søknadId, søknadbarnId)
+        opplysningRepository.lagreBarnSøknadMapping(søknadId)
 
         withMockAuthServerAndTestApplication(moduleFunction = testModuleFunction) {
             client
@@ -331,7 +331,7 @@ class OpplysningApiTest {
                 )
 
             opplysningRepository.lagre(opplysning)
-            opplysningRepository.lagreBarnSøknadMapping(søknadId, søknadbarnId)
+            opplysningRepository.lagreBarnSøknadMapping(søknadId)
 
             withMockAuthServerAndTestApplication(moduleFunction = testModuleFunction) {
                 client

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/db/QuizOpplysningRepositoryPostgresTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/db/QuizOpplysningRepositoryPostgresTest.kt
@@ -458,10 +458,9 @@ class QuizOpplysningRepositoryPostgresTest {
     fun `mapTilSøknadbarnId returnerer søknadbarnId fra databasen hvis den eksisterer`() {
         withMigratedDb {
             val søknadId = randomUUID()
-            val søknadbarnId = randomUUID()
-            opplysningRepository.lagreBarnSøknadMapping(søknadId, søknadbarnId)
+            val lagretSøknadbarnId = opplysningRepository.lagreBarnSøknadMapping(søknadId)
 
-            opplysningRepository.hentEllerOpprettSøknadbarnId(søknadId) shouldBe søknadbarnId
+            opplysningRepository.hentEllerOpprettSøknadbarnId(søknadId) shouldBe lagretSøknadbarnId
         }
     }
 
@@ -491,10 +490,9 @@ class QuizOpplysningRepositoryPostgresTest {
     fun `mapTilSøknadId returnerer søknadId basert på søknadbarnId`() {
         withMigratedDb {
             val søknadId = randomUUID()
-            val søknadbarnId = randomUUID()
-            opplysningRepository.lagreBarnSøknadMapping(søknadId, søknadbarnId)
+            val lagretSøknadbarnId = opplysningRepository.lagreBarnSøknadMapping(søknadId)
 
-            opplysningRepository.mapTilSøknadId(søknadbarnId) shouldBe søknadId
+            opplysningRepository.mapTilSøknadId(lagretSøknadbarnId) shouldBe søknadId
         }
     }
 }

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/InMemoryQuizOpplysningRepository.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/InMemoryQuizOpplysningRepository.kt
@@ -6,6 +6,7 @@ import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.Barn
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.BarnSvar
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.db.QuizOpplysningRepository
 import java.util.UUID
+import java.util.UUID.randomUUID
 
 class InMemoryQuizOpplysningRepository : QuizOpplysningRepository {
     private val opplysninger = mutableListOf<QuizOpplysning<*>>()
@@ -57,16 +58,16 @@ class InMemoryQuizOpplysningRepository : QuizOpplysningRepository {
         opplysninger.add(oppdatertOpplysning)
     }
 
-    override fun lagreBarnSøknadMapping(
-        søknadId: UUID,
-        søknadbarnId: UUID,
-    ) {
+    override fun lagreBarnSøknadMapping(søknadId: UUID): UUID {
+        val søknadbarnId = randomUUID()
         barnSøknadMapper[søknadId] = søknadbarnId
+
+        return søknadbarnId
     }
 
     override fun hentEllerOpprettSøknadbarnId(søknadId: UUID): UUID =
         barnSøknadMapper.getOrElse(søknadId) {
-            val nySøknadbarnId = UUID.randomUUID()
+            val nySøknadbarnId = randomUUID()
             barnSøknadMapper[søknadId] = nySøknadbarnId
 
             nySøknadbarnId


### PR DESCRIPTION
Det kan skje at vi prøver å lagre en ny id når det allerede er lagret en id for den søknadId'en. Nå sjekker vi om det finnes en id fra før og returnerer i så fall den i stedet for å lagre noe nytt.