### PR TITLE
feature/hindre-at-rekkefølgen-på-json-endrer-seg

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/seksjon/SeksjonV2Tabell.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/seksjon/SeksjonV2Tabell.kt
@@ -5,14 +5,14 @@ import no.nav.dagpenger.soknad.orkestrator.søknad.db.SøknadTabell
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.javatime.datetime
-import org.jetbrains.exposed.sql.json.jsonb
+import org.jetbrains.exposed.sql.json.json
 import java.time.LocalDateTime
 import java.util.UUID
 
 object SeksjonV2Tabell : IntIdTable("seksjon_v2") {
     val seksjonId: Column<String> = text("seksjon_id")
     val søknadId: Column<UUID> = uuid("soknad_id").references(SøknadTabell.søknadId)
-    val json: Column<String> = jsonb("json", { serializeSøknadData(it) }, { it })
+    val json: Column<String> = json("json", { serializeSøknadData(it) }, { it })
     val opprettet: Column<LocalDateTime> = datetime("opprettet").default(LocalDateTime.now())
 }
 

--- a/src/main/resources/db/migration/V14__MIGRER_SEKSJON_V2_JSONB_TIL_JSON.sql
+++ b/src/main/resources/db/migration/V14__MIGRER_SEKSJON_V2_JSONB_TIL_JSON.sql
@@ -1,0 +1,2 @@
+ALTER TABLE seksjon_v2
+    ALTER COLUMN json TYPE json


### PR DESCRIPTION
Grunnen til at rekkefølgen på JSON-strukturen endrer seg er at vi bruker `jsonb` som datatype. PostgreSQL lagrer json i et binærformat for å mer effektivt kjøre JSON-funksjoner i SQL-queries, og da beholdes ikke rekkefølgen på elementene, ref. https://www.postgresql.org/docs/18/datatype-json.html.

Etter migrering til `json` som datatype vil alle JSON-operasjoner i SQL-queries fortsatt fungere, men de vil ikke være like effektive fordi PostgreSQL må parse JSON hver gang JSON-operasjoner kjøres.

Som et alternativ til å endre datatype til `json`, så kan vi legge inn en `index`-atributt på alle spørsmål ala `{"dette-er-et-spørsmål": "dette er svaret", index: 1}`, men dette kan bli mer jobb for oss å implementere, forvalte og feilsøke enn tiden PostgreSQL kommer til å bruke på å parse JSON-strukturen når JSON-funksjoner kjøres.

Etter migrering vil strukturen på alle JSON som allerede er lagret fortsatt være i "tilfeldig" rekkefølge, men nye vil bli lagret i databasen med riktig rekkefølge.

Jeg har ikke kjørt DB-migreringen i `dev`, tenkte å sjekke om alle var enige i at det var den beste tilnærmingen før jeg testet - så det er ikke 100% sikkert at migreringen fungerer.

Bumper til nyeste versjon av Gradle i samme slengen også.