### PR TITLE
Svar med tomme verdier når søknad ikke finnes i databasen

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløser.kt
@@ -53,6 +53,23 @@ class SøknadsdataBehovløser(
                     safKlient.hentSøknadUuid(journalpostId)
                 }
 
+        if (søknadRepository.hent(søknadId) == null) {
+            logger.warn { "Fant ikke søknad for søknadId: $søknadId hentet fra SAF, svarer med tomme verdier" }
+            val behovmeldingMedSøknadId =
+                Behovmelding(
+                    behovmelding.innkommendePacket.apply {
+                        this["søknadId"] = søknadId.toString()
+                    },
+                )
+            return publiserLøsning(
+                behovmeldingMedSøknadId,
+                objectMapper.convertValue(
+                    tomSøknadsdataResultat(søknadId),
+                    object : TypeReference<Map<String, Any?>>() {},
+                ),
+            )
+        }
+
         val erOrkestratorSøknad = opplysningRepository.hentAlle(søknadId).isEmpty()
 
         val eøsBostedsland = eøsBostedsland(behovmelding.ident, søknadId)
@@ -98,10 +115,10 @@ class SøknadsdataBehovløser(
                 reellArbeidssøker = reellArbeidssøker,
             )
 
-        val søknadsdataMap: Map<String, Any> =
+        val søknadsdataMap: Map<String, Any?> =
             objectMapper.convertValue(
                 søknadsdataResultat,
-                object : TypeReference<Map<String, Any>>() {},
+                object : TypeReference<Map<String, Any?>>() {},
             )
 
         val behovmeldingMedSøknadId: Behovmelding =
@@ -407,6 +424,19 @@ class SøknadsdataBehovløser(
             "HUN",
             "AUT",
         )
+
+    private fun tomSøknadsdataResultat(søknadId: UUID) =
+        SøknadsdataResultType(
+            eøsBostedsland = false,
+            eøsArbeidsforhold = false,
+            avtjentVerneplikt = false,
+            avsluttetArbeidsforhold = emptyList(),
+            harBarn = false,
+            harAndreYtelser = false,
+            ønskerDagpengerFraDato = null,
+            søknadUuid = søknadId.toString(),
+            reellArbeidssøker = ReellArbeidssøker(helse = false, geografi = false, deltid = false, yrke = false),
+        )
 }
 
 data class SøknadsdataResultType(
@@ -416,7 +446,7 @@ data class SøknadsdataResultType(
     val avsluttetArbeidsforhold: List<AvsluttedeArbeidsforhold>,
     val harBarn: Boolean,
     val harAndreYtelser: Boolean,
-    val ønskerDagpengerFraDato: LocalDate,
+    val ønskerDagpengerFraDato: LocalDate?,
     @field:JsonProperty("søknad_uuid")
     val søknadUuid: String,
     val reellArbeidssøker: ReellArbeidssøker,

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløserTest.kt
@@ -1234,4 +1234,26 @@ class SøknadsdataBehovløserTest {
             verdi["søknad_uuid"].asUUID() shouldBe safSøknadId
         }
     }
+
+    @Test
+    fun `svarer med tomme verdier når søknad fra SAF ikke finnes i databasen`() {
+        val safSøknadId = UUID.randomUUID()
+        every { søknadRepository.hentSøknadIdFraJournalPostId(any(), any()) } returns null
+        every { safKlient.hentSøknadUuid(any()) } returns safSøknadId
+        every { søknadRepository.hent(safSøknadId) } returns null
+
+        behovløser.løs(lagBehovmeldingUtenSøknadId(ident))
+
+        testRapid.inspektør.message(0)["@løsning"]["Søknadsdata"].also { løsning ->
+            val verdi = løsning["verdi"]
+            verdi["søknad_uuid"].asUUID() shouldBe safSøknadId
+            verdi["eøsBostedsland"].asBoolean() shouldBe false
+            verdi["eøsArbeidsforhold"].asBoolean() shouldBe false
+            verdi["avtjentVerneplikt"].asBoolean() shouldBe false
+            verdi["harBarn"].asBoolean() shouldBe false
+            verdi["harAndreYtelser"].asBoolean() shouldBe false
+            verdi["avsluttetArbeidsforhold"].isEmpty shouldBe true
+            verdi["ønskerDagpengerFraDato"].isNull shouldBe true
+        }
+    }
 }


### PR DESCRIPTION
Når søknadId er hentet fra SAF men ikke finnes i vår database, svarer vi nå med alle false-verdier i stedet for å krasje. søknad_uuid settes til den faktiske IDen vi fant.