### PR TITLE
Legg til kilde-label og nye metrikker for søknad-flyt

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/metrikker/Metrikker.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/metrikker/Metrikker.kt
@@ -5,18 +5,34 @@ import io.prometheus.metrics.core.metrics.Counter
 private const val NAMESPACE = "dp_soknad_orkestrator"
 
 object SøknadMetrikker {
+    val opprettet: Counter =
+        Counter
+            .builder()
+            .name("${NAMESPACE}_antall_soknader_opprettet")
+            .help("Indikerer antall nye søknader som er opprettet (ny søknad-flyt)")
+            .register()
+
     val mottatt: Counter =
         Counter
             .builder()
             .name("${NAMESPACE}_antall_soknader_mottatt")
-            .help("Indikerer antall søknader som er mottatt")
+            .help("Indikerer antall søknader som er mottatt/innsendt. Label 'kilde': 'ny' (orkestrator) eller 'quiz' (gammel flyt)")
+            .labelNames("kilde")
             .register()
 
     val slettet: Counter =
         Counter
             .builder()
             .name("${NAMESPACE}_antall_soknader_slettet")
-            .help("Indikerer antall søknader som er slettet")
+            .help("Indikerer antall søknader som er slettet. Label 'kilde': 'ny' (orkestrator) eller 'quiz' (gammel flyt)")
+            .labelNames("kilde")
+            .register()
+
+    val journalfort: Counter =
+        Counter
+            .builder()
+            .name("${NAMESPACE}_antall_soknader_journalfort")
+            .help("Indikerer antall søknader som er journalført (ny søknad-flyt)")
             .register()
 
     val varslet: Counter =

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadApi.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadApi.kt
@@ -56,7 +56,7 @@ internal fun Application.søknadApi(
                 delete {
                     val søknadId = validerOgFormaterSøknadIdParam() ?: return@delete
 
-                    søknadService.slettSøknadOgInkrementerMetrikk(søknadId, call.ident())
+                    søknadService.slettSøknadOgInkrementerMetrikk(søknadId, call.ident(), "ny")
 
                     call.respond(OK, "Søknad $søknadId er slettet")
                 }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadService.kt
@@ -68,6 +68,7 @@ class SøknadService(
     internal fun slettSøknadOgInkrementerMetrikk(
         søknadId: UUID,
         ident: String,
+        kilde: String,
     ) {
         val søknad =
             søknadRepository.hent(søknadId)
@@ -80,13 +81,14 @@ class SøknadService(
 
         sendEndretTilstandTilSlettetMelding(søknadId, ident, søknad)
 
-        SøknadMetrikker.slettet.inc()
+        SøknadMetrikker.slettet.labelValues(kilde).inc()
         logg.info { "Slettet søknad med søknadId: $søknadId" }
         sikkerlogg.info { "Slettet søknad med søknadId: $søknadId og ident: $ident" }
     }
 
     fun opprett(ident: String): UUID {
         val søknadId = søknadRepository.opprett(Søknad(ident = ident))
+        SøknadMetrikker.opprettet.inc()
         logg.info { "Opprettet søknad med søknadId $søknadId" }
         sikkerlogg.info { "Opprettet søknad med søknadId $søknadId for $ident" }
 
@@ -118,7 +120,7 @@ class SøknadService(
         val melding = MeldingOmSøknadKlarTilJournalføring(søknadId, ident)
 
         rapidsConnection.publish(ident, melding.asMessage().toJson())
-        SøknadMetrikker.mottatt.inc()
+        SøknadMetrikker.mottatt.labelValues("ny").inc()
 
         logg.info { "Publiserte melding om søknad klar til journalføring med søknadId: $søknadId" }
         sikkerlogg.info { "Publiserte melding om søknad klar til journalføring med søknadId: $søknadId og ident: $ident" }
@@ -138,6 +140,7 @@ class SøknadService(
 
             sendEndretTilstandTilSlettetMelding(søknad.søknadId, søknad.ident, søknad)
 
+            SøknadMetrikker.slettet.labelValues("ny").inc()
             sikkerlogg.info { "Automatisk jobb slettet søknad ${søknad.søknadId} og tilhørende seksjoner opprettet av ${søknad.ident}" }
         }
     }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/SøknadMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/SøknadMottak.kt
@@ -51,7 +51,7 @@ class SøknadMottak(
                 return@withMDC
             }
             logger.info { "Mottok søknad innsendt hendelse for søknad ${packet["søknadId"]}" }
-            SøknadMetrikker.mottatt.inc()
+            SøknadMetrikker.mottatt.labelValues("quiz").inc()
             sikkerlogg.info { "Mottok søknad innsendt hendelse: ${packet.toJson()}" }
 
             val søknadmelding = objectMapper.readTree(packet.toJson())

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/SøknadPdfOgVedleggJournalførtMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/SøknadPdfOgVedleggJournalførtMottak.kt
@@ -9,6 +9,7 @@ import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.oshai.kotlinlogging.withLoggingContext
 import io.micrometer.core.instrument.MeterRegistry
+import no.nav.dagpenger.soknad.orkestrator.metrikker.SøknadMetrikker
 import no.nav.dagpenger.soknad.orkestrator.søknad.db.SøknadRepository
 import no.nav.dagpenger.soknad.orkestrator.utils.asUUID
 
@@ -64,6 +65,7 @@ internal class SøknadPdfOgVedleggJournalførtMottak(
             søknadRepository.hent(søknadId)?.let {
                 if (it.ident == ident) {
                     søknadRepository.markerSøknadSomJournalført(søknadId, ident, journalpostId, journalførtTidspunkt)
+                    SøknadMetrikker.journalfort.inc()
                     logg.info { "Søknad $søknadId markert som journalført" }
                     sikkerLogg.info { "Søknad $søknadId innsendt av $ident markert som journaført med journalpostId $journalpostId" }
                 } else {

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/SøknadSlettetMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/SøknadSlettetMottak.kt
@@ -43,7 +43,7 @@ class SøknadSlettetMottak(
             val søknadId = packet["søknad_uuid"].asUUID()
             val ident = packet["ident"].asText()
 
-            søknadService.slettSøknadOgInkrementerMetrikk(søknadId, ident)
+            søknadService.slettSøknadOgInkrementerMetrikk(søknadId, ident, "quiz")
         }
     }
 

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadApiTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadApiTest.kt
@@ -334,7 +334,7 @@ class SøknadApiTest {
     fun `DELETE søknad med søknadId returnerer 200 OK hvis sletting av seksjoner går bra`() {
         val søknadId = randomUUID()
         every {
-            søknadService.slettSøknadOgInkrementerMetrikk(søknadId, any())
+            søknadService.slettSøknadOgInkrementerMetrikk(søknadId, any(), "ny")
         } returns Unit
 
         withMockAuthServerAndTestApplication(moduleFunction = testModuleFunction) {
@@ -376,7 +376,7 @@ class SøknadApiTest {
     fun `DELETE søknad returnerer 500 Internal Server Error hvis sletting av seksjoner feiler`() {
         val søknadId = randomUUID()
         every {
-            søknadService.slettSøknadOgInkrementerMetrikk(søknadId, any())
+            søknadService.slettSøknadOgInkrementerMetrikk(søknadId, any(), "ny")
         } throws IllegalStateException()
 
         withMockAuthServerAndTestApplication(moduleFunction = testModuleFunction) {

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadServiceTest.kt
@@ -113,7 +113,7 @@ class SøknadServiceTest {
             søknadRepository.hent(søknad.søknadId)
         } returns søknad
 
-        søknadService.slettSøknadOgInkrementerMetrikk(søknadId, ident)
+        søknadService.slettSøknadOgInkrementerMetrikk(søknadId, ident, "ny")
 
         verify { søknadRepository.slett(søknadId, ident) }
         with(testRapid.inspektør) {
@@ -136,7 +136,7 @@ class SøknadServiceTest {
             søknadRepository.hent(søknadId)
         } returns null
 
-        søknadService.slettSøknadOgInkrementerMetrikk(søknadId, ident)
+        søknadService.slettSøknadOgInkrementerMetrikk(søknadId, ident, "ny")
 
         verify(exactly = 0) { søknadRepository.slett(søknadId, ident) }
         with(testRapid.inspektør) {

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadSlettetMottakTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadSlettetMottakTest.kt
@@ -24,21 +24,21 @@ class SøknadSlettetMottakTest {
     fun `Skal slette søknad når søknad_slettet event mottas`() {
         testRapid.sendTestMessage(søknadSlettetEvent)
 
-        verify { søknadService.slettSøknadOgInkrementerMetrikk(søknadId, ident) }
+        verify { søknadService.slettSøknadOgInkrementerMetrikk(søknadId, ident, "quiz") }
     }
 
     @Test
     fun `Tar ikke i mot søknad_slettet event når påkrevd felt ident mangler`() {
         testRapid.sendTestMessage(søknadSlettetEventUtenIdent)
 
-        verify(exactly = 0) { søknadService.slettSøknadOgInkrementerMetrikk(any(), any()) }
+        verify(exactly = 0) { søknadService.slettSøknadOgInkrementerMetrikk(any(), any(), any()) }
     }
 
     @Test
     fun `Tar ikke i mot søknad_slettet event når påkrevd felt søknadId mangler`() {
         testRapid.sendTestMessage(søknadSlettetEventUtenSøknadId)
 
-        verify(exactly = 0) { søknadService.slettSøknadOgInkrementerMetrikk(any(), any()) }
+        verify(exactly = 0) { søknadService.slettSøknadOgInkrementerMetrikk(any(), any(), any()) }
     }
 
     private val søknadSlettetEvent =


### PR DESCRIPTION
Skiller mellom ny søknad-flyt (orkestrator) og gammel quiz-flyt ved hjelp av label kilde='ny'/'quiz' på delte metrikker.

- mottatt{kilde} og slettet{kilde} skiller nå mellom flytene
- Ny opprettet-metrikk for når ny søknad opprettes (PÅBEGYNT)
- Ny journalfort-metrikk for når ny søknad journalføres
- Auto-slettet søknader telles nå også