### PR TITLE
Håndter SAF 404 i Søknadsdata

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/Behovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/Behovløser.kt
@@ -73,7 +73,27 @@ abstract class Behovløser(
         behovmelding: Behovmelding,
         svarPåBehov: Any,
     ) {
-        leggLøsningPåBehovmelding(behovmelding, svarPåBehov)
+        leggLøsningPåBehovmelding(
+            behovmelding.innkommendePacket,
+            svarPåBehov,
+            finnGjelderFraDato(behovmelding.søknadId, behovmelding.ident),
+        )
+        rapidsConnection.publish(behovmelding.ident, behovmelding.innkommendePacket.toJson())
+
+        BehovMetrikker.løst.labelValues(behov).inc()
+        logger.info { "Løste behov $behov" }
+        sikkerlogg.info { "Løste behov $behov med løsning: $svarPåBehov" }
+    }
+
+    internal fun publiserLøsning(
+        behovmelding: SøknadBehovmelding,
+        svarPåBehov: Any,
+    ) {
+        leggLøsningPåBehovmelding(
+            behovmelding.innkommendePacket,
+            svarPåBehov,
+            gjelderFra = null,
+        )
         rapidsConnection.publish(behovmelding.ident, behovmelding.innkommendePacket.toJson())
 
         BehovMetrikker.løst.labelValues(behov).inc()
@@ -82,12 +102,11 @@ abstract class Behovløser(
     }
 
     private fun leggLøsningPåBehovmelding(
-        behovmelding: Behovmelding,
+        innkommendePacket: JsonMessage,
         svarPåBehov: Any,
+        gjelderFra: LocalDate?,
     ) {
-        val gjelderFra: LocalDate? = finnGjelderFraDato(behovmelding.søknadId, behovmelding.ident)
-
-        behovmelding.innkommendePacket["@løsning"] =
+        innkommendePacket["@løsning"] =
             mapOf(
                 behov to
                     mapOf(

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløser.kt
@@ -53,6 +53,17 @@ class SøknadsdataBehovløser(
                     safKlient.hentSøknadUuid(journalpostId)
                 }
 
+        if (søknadId == null) {
+            logger.warn { "Fant ikke søknad_uuid i SAF for journalpostId: $journalpostId, svarer med tomme verdier" }
+            return publiserLøsning(
+                behovmelding,
+                objectMapper.convertValue(
+                    tomSøknadsdataResultat(),
+                    object : TypeReference<Map<String, Any?>>() {},
+                ),
+            )
+        }
+
         if (søknadRepository.hent(søknadId) == null) {
             logger.warn { "Fant ikke søknad for søknadId: $søknadId hentet fra SAF, svarer med tomme verdier" }
             val behovmeldingMedSøknadId =
@@ -425,7 +436,7 @@ class SøknadsdataBehovløser(
             "AUT",
         )
 
-    private fun tomSøknadsdataResultat(søknadId: UUID) =
+    private fun tomSøknadsdataResultat(søknadId: UUID? = null) =
         SøknadsdataResultType(
             eøsBostedsland = false,
             eøsArbeidsforhold = false,
@@ -434,7 +445,7 @@ class SøknadsdataBehovløser(
             harBarn = false,
             harAndreYtelser = false,
             ønskerDagpengerFraDato = null,
-            søknadUuid = søknadId.toString(),
+            søknadUuid = søknadId?.toString(),
             reellArbeidssøker = ReellArbeidssøker(helse = false, geografi = false, deltid = false, yrke = false),
         )
 }
@@ -448,7 +459,7 @@ data class SøknadsdataResultType(
     val harAndreYtelser: Boolean,
     val ønskerDagpengerFraDato: LocalDate?,
     @field:JsonProperty("søknad_uuid")
-    val søknadUuid: String,
+    val søknadUuid: String?,
     val reellArbeidssøker: ReellArbeidssøker,
 )
 

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/saf/SafKlient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/saf/SafKlient.kt
@@ -2,6 +2,7 @@ package no.nav.dagpenger.soknad.orkestrator.saf
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -10,6 +11,7 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import kotlinx.coroutines.runBlocking
 import no.nav.dagpenger.oauth2.CachedOauth2Client
@@ -41,7 +43,7 @@ class SafKlient(
         azureAdClient.clientCredentials(safScope).access_token
             ?: throw RuntimeException("Klarte ikke hente SAF-token")
 
-    fun hentSøknadUuid(journalpostId: String): UUID =
+    fun hentSøknadUuid(journalpostId: String): UUID? =
         runBlocking {
             try {
                 logger.info { "Slår opp journalpost i SAF for journalpostId: $journalpostId" }
@@ -59,6 +61,14 @@ class SafKlient(
                         )
 
                 UUID.fromString(søknadUuid)
+            } catch (e: ClientRequestException) {
+                if (e.response.status == HttpStatusCode.NotFound) {
+                    logger.warn { "Fant ikke dokument i SAF for journalpostId: $journalpostId, svarer uten søknad_uuid" }
+                    null
+                } else {
+                    logger.error(e) { "SAF-oppslag feilet for journalpostId: $journalpostId" }
+                    throw e
+                }
             } catch (e: Exception) {
                 logger.error(e) { "SAF-oppslag feilet for journalpostId: $journalpostId" }
                 throw e

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløserTest.kt
@@ -1254,6 +1254,34 @@ class SøknadsdataBehovløserTest {
             verdi["harAndreYtelser"].asBoolean() shouldBe false
             verdi["avsluttetArbeidsforhold"].isEmpty shouldBe true
             verdi["ønskerDagpengerFraDato"].isNull shouldBe true
+            verdi["reellArbeidssøker"]["helse"].asBoolean() shouldBe false
+            verdi["reellArbeidssøker"]["geografi"].asBoolean() shouldBe false
+            verdi["reellArbeidssøker"]["deltid"].asBoolean() shouldBe false
+            verdi["reellArbeidssøker"]["yrke"].asBoolean() shouldBe false
+        }
+    }
+
+    @Test
+    fun `svarer med tomme verdier når SAF ikke finner dokument`() {
+        every { søknadRepository.hentSøknadIdFraJournalPostId(any(), any()) } returns null
+        every { safKlient.hentSøknadUuid(any()) } returns null
+
+        behovløser.løs(lagBehovmeldingUtenSøknadId(ident))
+
+        testRapid.inspektør.message(0)["@løsning"]["Søknadsdata"].also { løsning ->
+            val verdi = løsning["verdi"]
+            verdi["søknad_uuid"].isNull shouldBe true
+            verdi["eøsBostedsland"].asBoolean() shouldBe false
+            verdi["eøsArbeidsforhold"].asBoolean() shouldBe false
+            verdi["avtjentVerneplikt"].asBoolean() shouldBe false
+            verdi["harBarn"].asBoolean() shouldBe false
+            verdi["harAndreYtelser"].asBoolean() shouldBe false
+            verdi["avsluttetArbeidsforhold"].isEmpty shouldBe true
+            verdi["ønskerDagpengerFraDato"].isNull shouldBe true
+            verdi["reellArbeidssøker"]["helse"].asBoolean() shouldBe false
+            verdi["reellArbeidssøker"]["geografi"].asBoolean() shouldBe false
+            verdi["reellArbeidssøker"]["deltid"].asBoolean() shouldBe false
+            verdi["reellArbeidssøker"]["yrke"].asBoolean() shouldBe false
         }
     }
 }


### PR DESCRIPTION
Svar med tomme verdier når SAF ikke finner dokumentet, på samme måte som når søknaden mangler i databasen. Behold søknad_uuid når vi har den, ellers la den være null.