### PR TITLE
Send ikke gyldigFraOgMed/TilOgMed for barn-opplysning til dp-behandling

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/OpplysningService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/OpplysningService.kt
@@ -260,8 +260,7 @@ class OpplysningService(
             NyOpplysningDTO(
                 verdi = objectMapper.writeValueAsString(BarnetilleggV2Løsning(søknadbarnId, løsningsbarn)),
                 begrunnelse = barn.begrunnelse,
-                gyldigFraOgMed = nyttBarnSvar.barnetilleggFom,
-                gyldigTilOgMed = nyttBarnSvar.barnetilleggTom,
+                gyldigFraOgMed = tidligsteBarnetilleggFom(alleBarnEtterEndring),
             )
 
         val behandlingId = barnRequest.behandlingId
@@ -311,8 +310,7 @@ class OpplysningService(
             NyOpplysningDTO(
                 verdi = objectMapper.writeValueAsString(BarnetilleggV2Løsning(søknadbarnId, løsningsbarn)),
                 begrunnelse = barn.begrunnelse,
-                gyldigFraOgMed = barn.barnetilleggFom,
-                gyldigTilOgMed = barn.barnetilleggTom,
+                gyldigFraOgMed = tidligsteBarnetilleggFom(alleBarn),
             )
 
         val behandlingId =
@@ -332,5 +330,8 @@ class OpplysningService(
 
     private companion object {
         private val logger = KotlinLogging.logger {}
+
+        fun tidligsteBarnetilleggFom(barn: List<BarnSvar>) =
+            barn.filter { it.kvalifisererTilBarnetillegg }.mapNotNull { it.barnetilleggFom }.minOrNull()
     }
 }

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/OpplysningServiceTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/OpplysningServiceTest.kt
@@ -623,6 +623,8 @@ class OpplysningServiceTest {
             )
         }
         løsning.søknadbarnId shouldBe søknadbarnId
+        fangetDpBehandlingOpplysning.gyldigFraOgMed shouldBe LocalDate.of(2020, 1, 1)
+        fangetDpBehandlingOpplysning.gyldigTilOgMed shouldBe null
     }
 
     @Test
@@ -819,8 +821,8 @@ class OpplysningServiceTest {
         løsning.barn.size shouldBe 1
         løsning.barn[0].fornavnOgMellomnavn shouldBe "Nytt"
         fangetOpplysning.begrunnelse shouldBe "Begrunnelse"
-        fangetOpplysning.gyldigFraOgMed shouldBe Barn.barnetilleggperiode(LocalDate.of(2020, 1, 1)).first
-        fangetOpplysning.gyldigTilOgMed shouldBe Barn.barnetilleggperiode(LocalDate.of(2020, 1, 1)).second
+        fangetOpplysning.gyldigFraOgMed shouldBe LocalDate.of(2020, 1, 1)
+        fangetOpplysning.gyldigTilOgMed shouldBe null
     }
 
     @Test


### PR DESCRIPTION
Perioden ble satt til barnetilleggFom/Tom for det redigerte barnet, som kunne ligge frem i tid. dp-behandling lagret da opplysningen med en gyldighetsperiode som ikke matchet prøvingsdato, og fastsettelser ble aldri oppdatert selv om POST returnerte 200 OK.

dp-behandling bruker bare kvalifiserer per barn for å telle antall barn med rett til barnetillegg – ingen per-barn-datoer i regelmotoren. Null gyldighetsperiode betyr opplysningen er alltid gyldig, i tråd med hva Kafka-behovløserflyten gjør.