### PR TITLE
Sett riktig skjemakode på hoveddokument ved ettersending

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/ApplicationBuilder.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/ApplicationBuilder.kt
@@ -70,7 +70,13 @@ internal class ApplicationBuilder(
     private val søknadPersonaliaRepository = SøknadPersonaliaRepository(dataSource)
 
     private val seksjonRepository = SeksjonRepository(dataSource, søknadRepository)
-    private val seksjonService = SeksjonService(seksjonRepository, søknadRepository)
+    private val søknadService: SøknadService =
+        SøknadService(
+            søknadRepository = søknadRepository,
+            søknadPersonaliaRepository = søknadPersonaliaRepository,
+            seksjonRepository = seksjonRepository,
+        )
+    private val seksjonService = SeksjonService(seksjonRepository, søknadRepository, søknadService)
     private val personaliaService =
         PersonaliaService(
             personService =
@@ -93,13 +99,6 @@ internal class ApplicationBuilder(
                         scope = Configuration.pdlApiSystemScope,
                     ).access_token ?: throw RuntimeException("Kunne ikke hente token")
             },
-        )
-
-    private val søknadService: SøknadService =
-        SøknadService(
-            søknadRepository = søknadRepository,
-            søknadPersonaliaRepository = søknadPersonaliaRepository,
-            seksjonRepository = seksjonRepository,
         )
 
     private val journalføringService = JournalføringService()

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløser.kt
@@ -46,12 +46,16 @@ class SøknadsdataBehovløser(
                 "Mangler journalpostId i behov for søknadsdata for søknaden",
             )
 
+        logger.info { "Løser Søknadsdata-behov for journalpostId=$journalpostId" }
+
         val søknadId =
             søknadRepository.hentSøknadIdFraJournalPostId(journalpostId, behovmelding.ident)
                 ?: run {
                     logger.info { "Fant ikke søknadId for journalpostId: $journalpostId, slår opp i SAF" }
                     safKlient.hentSøknadUuid(journalpostId)
                 }
+
+        logger.info { "Fant søknadId=$søknadId for journalpostId=$journalpostId" }
 
         if (søknadId == null) {
             logger.warn { "Fant ikke søknad_uuid i SAF for journalpostId: $journalpostId, svarer med tomt objekt" }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/saf/SafKlient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/saf/SafKlient.kt
@@ -48,6 +48,15 @@ class SafKlient(
             try {
                 logger.info { "Slår opp journalpost i SAF for journalpostId: $journalpostId" }
                 val journalpost = hentJournalpost(journalpostId)
+
+                val brevkode = journalpost.hovedDokument.brevkode
+                if (brevkode != null && brevkode.startsWith("NAVe")) {
+                    logger.warn {
+                        "Journalpost $journalpostId er en ettersending (brevkode=$brevkode) — returnerer null uten å hente dokumentinnhold"
+                    }
+                    return@runBlocking null
+                }
+
                 val dokumentInfoId = journalpost.hovedDokument.dokumentInfoId
 
                 sikkerlogg.info { "Henter søknadsdata fra SAF for journalpostId: $journalpostId, dokumentInfoId: $dokumentInfoId" }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/seksjon/SeksjonService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/seksjon/SeksjonService.kt
@@ -5,6 +5,7 @@ import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.dagpenger.soknad.orkestrator.søknad.Dokument
 import no.nav.dagpenger.soknad.orkestrator.søknad.Dokumentvariant
+import no.nav.dagpenger.soknad.orkestrator.søknad.SøknadService
 import no.nav.dagpenger.soknad.orkestrator.søknad.Tilstand
 import no.nav.dagpenger.soknad.orkestrator.søknad.db.SøknadRepository
 import no.nav.dagpenger.soknad.orkestrator.søknad.melding.MeldingOmEttersending
@@ -14,6 +15,7 @@ import java.util.UUID
 class SeksjonService(
     val seksjonRepository: SeksjonRepository,
     val søknadRepository: SøknadRepository,
+    val søknadService: SøknadService,
 ) {
     private companion object {
         private val logg = KotlinLogging.logger {}
@@ -89,13 +91,16 @@ class SeksjonService(
         seksjonId: String,
         dokumentasjonskrav: String,
     ) {
+        val hoveddokumentSkjemakode = søknadService.finnSkjemaKode(ident, søknadId, forventetFullførtSøknad = false)
+        logg.info { "Sender ettersending for søknadId=$søknadId, hoveddokumentSkjemakode=$hoveddokumentSkjemakode" }
         val event =
             MeldingOmEttersending(
                 søknadId = søknadId,
                 ident = ident,
                 dokumentKravene =
                     opprettDokumenterFraDokumentasjonskravEttersending(
-                        dokumentasjonskrav,
+                        dokumentasjonskrav = dokumentasjonskrav,
+                        hoveddokumentSkjemakode = hoveddokumentSkjemakode,
                     ),
                 dokumentasjonskravJson = dokumentasjonskrav,
                 seksjonId = seksjonId,
@@ -106,32 +111,41 @@ class SeksjonService(
         )
     }
 
-    fun opprettDokumenterFraDokumentasjonskravEttersending(dokumentasjonskrav: String): List<Dokument> =
-        jsonMapper
-            .readTree(dokumentasjonskrav)
-            .toList()
-            .mapNotNull { rootNode ->
-                rootNode
-                    .findValue("bundle")
-                    ?.let { bundleNode ->
-                        if (!bundleNode.isEmpty) {
-                            Dokument(
-                                skjemakode = rootNode.at("/skjemakode").textValue(),
-                                varianter =
-                                    listOf(
-                                        Dokumentvariant(
-                                            filnavn = bundleNode.at("/filnavn").textValue(),
-                                            urn = bundleNode.at("/urn").textValue(),
-                                            variant = "ARKIV",
-                                            type = "PDF",
+    fun opprettDokumenterFraDokumentasjonskravEttersending(
+        dokumentasjonskrav: String,
+        hoveddokumentSkjemakode: String? = null,
+    ): List<Dokument> {
+        val dokumenter =
+            jsonMapper
+                .readTree(dokumentasjonskrav)
+                .toList()
+                .mapNotNull { rootNode ->
+                    rootNode
+                        .findValue("bundle")
+                        ?.let { bundleNode ->
+                            if (!bundleNode.isEmpty) {
+                                Dokument(
+                                    skjemakode = rootNode.at("/skjemakode").textValue(),
+                                    varianter =
+                                        listOf(
+                                            Dokumentvariant(
+                                                filnavn = bundleNode.at("/filnavn").textValue(),
+                                                urn = bundleNode.at("/urn").textValue(),
+                                                variant = "ARKIV",
+                                                type = "PDF",
+                                            ),
                                         ),
-                                    ),
-                            )
-                        } else {
-                            null
+                                )
+                            } else {
+                                null
+                            }
                         }
-                    }
-            }
+                }
+        if (hoveddokumentSkjemakode != null && dokumenter.isNotEmpty()) {
+            return listOf(dokumenter.first().copy(skjemakode = hoveddokumentSkjemakode)) + dokumenter.drop(1)
+        }
+        return dokumenter
+    }
 }
 
 data class Seksjon(

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/saf/SafKlientTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/saf/SafKlientTest.kt
@@ -1,0 +1,115 @@
+package no.nav.dagpenger.soknad.orkestrator.saf
+
+import io.kotest.matchers.shouldBe
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.dagpenger.oauth2.CachedOauth2Client
+import no.nav.dagpenger.soknad.orkestrator.utils.configureHttpClient
+import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenResponse
+import kotlin.test.Test
+
+class SafKlientTest {
+    private val azureAdClient = mockk<CachedOauth2Client>()
+    private val tokenResponse = mockk<OAuth2AccessTokenResponse>()
+
+    init {
+        every { tokenResponse.access_token } returns "test-token"
+        every { azureAdClient.clientCredentials(any()) } returns tokenResponse
+    }
+
+    private fun lagSafKlient(mockEngine: MockEngine) =
+        SafKlient(
+            azureAdClient = azureAdClient,
+            safUrl = "http://localhost",
+            safScope = "test-scope",
+            httpClient = configureHttpClient(mockEngine),
+        )
+
+    @Test
+    fun `hentSøknadUuid returnerer null for NAVe-brevkode uten å hente dokumentinnhold`() {
+        var antallRequests = 0
+        val mockEngine =
+            MockEngine { _ ->
+                antallRequests++
+                respond(
+                    content = ettersendingGraphQlRespons,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                )
+            }
+
+        val resultat = lagSafKlient(mockEngine).hentSøknadUuid("123456789")
+
+        resultat shouldBe null
+        antallRequests shouldBe 1
+    }
+
+    @Test
+    fun `hentSøknadUuid henter dokumentinnhold for ikke-NAVe-brevkode`() {
+        var antallRequests = 0
+        val mockEngine =
+            MockEngine { _ ->
+                antallRequests++
+                if (antallRequests == 1) {
+                    respond(
+                        content = vanligSøknadGraphQlRespons,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                    )
+                } else {
+                    respond(
+                        content = """{"søknad_uuid": "550e8400-e29b-41d4-a716-446655440000"}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                    )
+                }
+            }
+
+        val resultat = lagSafKlient(mockEngine).hentSøknadUuid("123456789")
+
+        resultat.toString() shouldBe "550e8400-e29b-41d4-a716-446655440000"
+        antallRequests shouldBe 2
+    }
+}
+
+private val ettersendingGraphQlRespons =
+    """
+    {
+      "data": {
+        "journalpost": {
+          "journalpostId": "123456789",
+          "dokumenter": [
+            {
+              "dokumentInfoId": "dok-1",
+              "brevkode": "NAVe 04-01.03",
+              "tittel": "Ettersending til søknad om dagpenger"
+            }
+          ]
+        }
+      }
+    }
+    """.trimIndent()
+
+private val vanligSøknadGraphQlRespons =
+    """
+    {
+      "data": {
+        "journalpost": {
+          "journalpostId": "123456789",
+          "dokumenter": [
+            {
+              "dokumentInfoId": "dok-1",
+              "brevkode": "NAV 04-01.03",
+              "tittel": "Søknad om dagpenger"
+            }
+          ]
+        }
+      }
+    }
+    """.trimIndent()

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/seksjon/SeksjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/seksjon/SeksjonServiceTest.kt
@@ -1,0 +1,95 @@
+package no.nav.dagpenger.soknad.orkestrator.søknad.seksjon
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.dagpenger.soknad.orkestrator.søknad.SøknadService
+import no.nav.dagpenger.soknad.orkestrator.søknad.db.SøknadRepository
+import kotlin.test.Test
+
+class SeksjonServiceTest {
+    private val seksjonRepository = mockk<SeksjonRepository>(relaxed = true)
+    private val søknadRepository = mockk<SøknadRepository>(relaxed = true)
+    private val søknadService = mockk<SøknadService>(relaxed = true)
+    private val seksjonService = SeksjonService(seksjonRepository, søknadRepository, søknadService)
+
+    private val dokumentasjonskravMedToDokumenter =
+        """
+        [
+          {
+            "skjemakode": "T8",
+            "bundle": {
+              "filnavn": "vedlegg1.pdf",
+              "urn": "urn:vedlegg:abc/T8"
+            }
+          },
+          {
+            "skjemakode": "O2",
+            "bundle": {
+              "filnavn": "vedlegg2.pdf",
+              "urn": "urn:vedlegg:abc/O2"
+            }
+          }
+        ]
+        """.trimIndent()
+
+    private val dokumentasjonskravMedTomBundle =
+        """
+        [
+          {
+            "skjemakode": "T8",
+            "bundle": {}
+          }
+        ]
+        """.trimIndent()
+
+    @Test
+    fun `opprettDokumenterFraDokumentasjonskravEttersending setter hoveddokumentSkjemakode på første dokument`() {
+        val dokumenter =
+            seksjonService.opprettDokumenterFraDokumentasjonskravEttersending(
+                dokumentasjonskrav = dokumentasjonskravMedToDokumenter,
+                hoveddokumentSkjemakode = "04-01.03",
+            )
+
+        dokumenter.size shouldBe 2
+        dokumenter[0].skjemakode shouldBe "04-01.03"
+        dokumenter[1].skjemakode shouldBe "O2"
+    }
+
+    @Test
+    fun `opprettDokumenterFraDokumentasjonskravEttersending beholder originale skjemakoder når hoveddokumentSkjemakode er null`() {
+        val dokumenter =
+            seksjonService.opprettDokumenterFraDokumentasjonskravEttersending(
+                dokumentasjonskrav = dokumentasjonskravMedToDokumenter,
+                hoveddokumentSkjemakode = null,
+            )
+
+        dokumenter.size shouldBe 2
+        dokumenter[0].skjemakode shouldBe "T8"
+        dokumenter[1].skjemakode shouldBe "O2"
+    }
+
+    @Test
+    fun `opprettDokumenterFraDokumentasjonskravEttersending filtrerer ut dokumenter med tom bundle`() {
+        val dokumenter =
+            seksjonService.opprettDokumenterFraDokumentasjonskravEttersending(
+                dokumentasjonskrav = dokumentasjonskravMedTomBundle,
+                hoveddokumentSkjemakode = "04-01.03",
+            )
+
+        dokumenter.size shouldBe 0
+    }
+
+    @Test
+    fun `opprettDokumenterFraDokumentasjonskravEttersending bruker skjemakode fra søknadService`() {
+        every { søknadService.finnSkjemaKode(any(), any(), any()) } returns "04-16.04"
+
+        val dokumenter =
+            seksjonService.opprettDokumenterFraDokumentasjonskravEttersending(
+                dokumentasjonskrav = dokumentasjonskravMedToDokumenter,
+                hoveddokumentSkjemakode = "04-16.04",
+            )
+
+        dokumenter[0].skjemakode shouldBe "04-16.04"
+    }
+}


### PR DESCRIPTION
Ettersendinger fra dp-brukerdialog-frontend fikk skjemakode fra frontend (f.eks. 'T8', 'O2'), som dp-mottak kategoriserte som UkjentSkjemaKode og aldri sendte Søknadsdata-behov for. Disse havnet dermed på benk 4450.

Fikser to ting:

- SeksjonService: hoveddokumentet ved ettersending får skjemakode fra SøknadService.finnSkjemaKode() (basert på søkerens svar) istedenfor koden fra frontend-payloaden. dp-behov-journalforing legger på NAVe- prefiks, slik at dp-mottak kategoriserer det som Ettersending.

- SafKlient: returnerer null uten å hente dokumentinnhold dersom brevkoden starter med 'NAVe'. Ettersendinger inneholder PDF, ikke JSON, og ville krasjet ved parseforsøk. SøknadsdataBehovløser håndterer allerede null søknadId ved å svare med tomt objekt.