### PR TITLE
Lagre ettersending journalpostId → søknadId-mapping

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløser.kt
@@ -51,7 +51,11 @@ class SøknadsdataBehovløser(
         val søknadId =
             søknadRepository.hentSøknadIdFraJournalPostId(journalpostId, behovmelding.ident)
                 ?: run {
-                    logger.info { "Fant ikke søknadId for journalpostId: $journalpostId, slår opp i SAF" }
+                    logger.info { "Fant ikke søknadId for journalpostId: $journalpostId, slår opp i ettersending-mapping" }
+                    søknadRepository.hentSøknadIdFraEttersendingJournalpostId(journalpostId, behovmelding.ident)
+                }
+                ?: run {
+                    logger.info { "Fant ikke søknadId i ettersending-mapping for journalpostId: $journalpostId, slår opp i SAF" }
                     safKlient.hentSøknadUuid(journalpostId)
                 }
 

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/saf/SafKlient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/saf/SafKlient.kt
@@ -49,14 +49,6 @@ class SafKlient(
                 logger.info { "Slår opp journalpost i SAF for journalpostId: $journalpostId" }
                 val journalpost = hentJournalpost(journalpostId)
 
-                val brevkode = journalpost.hovedDokument.brevkode
-                if (brevkode != null && brevkode.startsWith("NAVe")) {
-                    logger.warn {
-                        "Journalpost $journalpostId er en ettersending (brevkode=$brevkode) — returnerer null uten å hente dokumentinnhold"
-                    }
-                    return@runBlocking null
-                }
-
                 val dokumentInfoId = journalpost.hovedDokument.dokumentInfoId
 
                 sikkerlogg.info { "Henter søknadsdata fra SAF for journalpostId: $journalpostId, dokumentInfoId: $dokumentInfoId" }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/db/SøknadRepository.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/db/SøknadRepository.kt
@@ -26,6 +26,7 @@ import org.jetbrains.exposed.sql.javatime.dateTimeLiteral
 import org.jetbrains.exposed.sql.javatime.datetime
 import org.jetbrains.exposed.sql.json.jsonb
 import org.jetbrains.exposed.sql.or
+import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.stringLiteral
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -284,6 +285,32 @@ class SøknadRepository(
                 .firstOrNull()
         }
 
+    fun lagreEttersendingJournalpostId(
+        søknadId: UUID,
+        journalpostId: String,
+    ) {
+        transaction {
+            EttersendingJournalpostTabell.insert {
+                it[EttersendingJournalpostTabell.søknadId] = søknadId
+                it[EttersendingJournalpostTabell.journalpostId] = journalpostId
+            }
+        }
+    }
+
+    fun hentSøknadIdFraEttersendingJournalpostId(
+        journalpostId: String,
+        ident: String,
+    ): UUID? =
+        transaction {
+            EttersendingJournalpostTabell
+                .innerJoin(SøknadTabell)
+                .select(EttersendingJournalpostTabell.søknadId)
+                .where { EttersendingJournalpostTabell.journalpostId eq journalpostId }
+                .andWhere { SøknadTabell.ident eq ident }
+                .map { it[EttersendingJournalpostTabell.søknadId] }
+                .firstOrNull()
+        }
+
     fun hentSoknaderForIdent(ident: String) =
         transaction {
             SøknadTabell
@@ -325,3 +352,9 @@ object SøknadDataTabell : IntIdTable("soknad_data") {
 private fun serializeSøknadData(søknadData: JsonNode): String = objectMapper.writeValueAsString(søknadData)
 
 private fun deserializeSøknadData(søknadData: String): JsonNode = objectMapper.readTree(søknadData)
+
+object EttersendingJournalpostTabell : IntIdTable("ettersending_journalpost") {
+    val opprettet: Column<LocalDateTime> = datetime("opprettet").default(now())
+    val søknadId: Column<UUID> = uuid("soknad_id").references(SøknadTabell.søknadId)
+    val journalpostId: Column<String> = varchar("journalpost_id", 32)
+}

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/MeldingOmEttersendingMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/MeldingOmEttersendingMottak.kt
@@ -60,6 +60,7 @@ internal class MeldingOmEttersendingMottak(
         val dokumentasjonskravJson =
             packet["@løsning"][BEHOV]["dokumentasjonskravJson"].asText()
         val seksjonId = packet["@løsning"][BEHOV]["seksjonId"].asText()
+        val journalpostId = packet["@løsning"][BEHOV]["journalpostId"].asText()
 
         withLoggingContext(
             "søknadId" to søknadId.toString(),
@@ -81,6 +82,7 @@ internal class MeldingOmEttersendingMottak(
                     dokumentasjonskrav = dokumentasjonskravJson,
                     oppdatertTidspunkt = oppdatertTidspunkt,
                 )
+                søknadRepository.lagreEttersendingJournalpostId(søknadId, journalpostId)
                 val dokumentKravInnsendtMelding =
                     DokumentKravInnsendtMelding(
                         søknadId = søknadId,

--- a/src/main/resources/db/migration/V23__CREATE_TABLE_ETTERSENDING_JOURNALPOST.sql
+++ b/src/main/resources/db/migration/V23__CREATE_TABLE_ETTERSENDING_JOURNALPOST.sql
@@ -1,0 +1,7 @@
+CREATE TABLE ettersending_journalpost
+(
+    id             SERIAL PRIMARY KEY,
+    soknad_id      UUID        NOT NULL REFERENCES soknad (soknad_id) ON DELETE CASCADE,
+    journalpost_id VARCHAR(32) NOT NULL UNIQUE,
+    opprettet      TIMESTAMP   NOT NULL DEFAULT NOW()
+);

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløserTest.kt
@@ -1214,6 +1214,7 @@ class SøknadsdataBehovløserTest {
     fun `slår opp søknadId i SAF når journalpostId ikke finnes i databasen`() {
         val safSøknadId = UUID.randomUUID()
         every { søknadRepository.hentSøknadIdFraJournalPostId(any(), any()) } returns null
+        every { søknadRepository.hentSøknadIdFraEttersendingJournalpostId(any(), any()) } returns null
         every { safKlient.hentSøknadUuid(any()) } returns safSøknadId
         every { seksjonRepository.hentSeksjonsvar(safSøknadId, ident, "personalia") } returns
             personaliaOrkestratorJson("ja", "NOR")
@@ -1239,6 +1240,7 @@ class SøknadsdataBehovløserTest {
     fun `svarer med tomme verdier når søknad fra SAF ikke finnes i databasen`() {
         val safSøknadId = UUID.randomUUID()
         every { søknadRepository.hentSøknadIdFraJournalPostId(any(), any()) } returns null
+        every { søknadRepository.hentSøknadIdFraEttersendingJournalpostId(any(), any()) } returns null
         every { safKlient.hentSøknadUuid(any()) } returns safSøknadId
         every { søknadRepository.hent(safSøknadId) } returns null
 
@@ -1264,6 +1266,7 @@ class SøknadsdataBehovløserTest {
     @Test
     fun `svarer med tomt objekt når SAF ikke finner dokument`() {
         every { søknadRepository.hentSøknadIdFraJournalPostId(any(), any()) } returns null
+        every { søknadRepository.hentSøknadIdFraEttersendingJournalpostId(any(), any()) } returns null
         every { safKlient.hentSøknadUuid(any()) } returns null
 
         behovløser.løs(lagBehovmeldingUtenSøknadId(ident))

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/saf/SafKlientTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/saf/SafKlientTest.kt
@@ -32,26 +32,7 @@ class SafKlientTest {
         )
 
     @Test
-    fun `hentSøknadUuid returnerer null for NAVe-brevkode uten å hente dokumentinnhold`() {
-        var antallRequests = 0
-        val mockEngine =
-            MockEngine { _ ->
-                antallRequests++
-                respond(
-                    content = ettersendingGraphQlRespons,
-                    status = HttpStatusCode.OK,
-                    headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
-                )
-            }
-
-        val resultat = lagSafKlient(mockEngine).hentSøknadUuid("123456789")
-
-        resultat shouldBe null
-        antallRequests shouldBe 1
-    }
-
-    @Test
-    fun `hentSøknadUuid henter dokumentinnhold for ikke-NAVe-brevkode`() {
+    fun `hentSøknadUuid henter journalpost og deretter dokumentinnhold`() {
         var antallRequests = 0
         val mockEngine =
             MockEngine { _ ->
@@ -77,24 +58,6 @@ class SafKlientTest {
         antallRequests shouldBe 2
     }
 }
-
-private val ettersendingGraphQlRespons =
-    """
-    {
-      "data": {
-        "journalpost": {
-          "journalpostId": "123456789",
-          "dokumenter": [
-            {
-              "dokumentInfoId": "dok-1",
-              "brevkode": "NAVe 04-01.03",
-              "tittel": "Ettersending til søknad om dagpenger"
-            }
-          ]
-        }
-      }
-    }
-    """.trimIndent()
 
 private val vanligSøknadGraphQlRespons =
     """

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/db/SøknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/db/SøknadRepositoryTest.kt
@@ -589,6 +589,33 @@ class SøknadRepositoryTest {
         }
         return søknadId
     }
+
+    @Test
+    fun `lagreEttersendingJournalpostId lagrer kobling mellom søknadId og journalpostId`() {
+        val søknadId = randomUUID()
+        søknadRepository.opprett(Søknad(søknadId, ident))
+
+        søknadRepository.lagreEttersendingJournalpostId(søknadId, "987654321")
+
+        val funnetSøknadId = søknadRepository.hentSøknadIdFraEttersendingJournalpostId("987654321", ident)
+        funnetSøknadId shouldBe søknadId
+    }
+
+    @Test
+    fun `hentSøknadIdFraEttersendingJournalpostId returnerer null når journalpostId ikke finnes`() {
+        val funnetSøknadId = søknadRepository.hentSøknadIdFraEttersendingJournalpostId("ukjent-id", ident)
+        funnetSøknadId shouldBe null
+    }
+
+    @Test
+    fun `hentSøknadIdFraEttersendingJournalpostId returnerer null når ident ikke matcher`() {
+        val søknadId = randomUUID()
+        søknadRepository.opprett(Søknad(søknadId, ident))
+        søknadRepository.lagreEttersendingJournalpostId(søknadId, "111222333")
+
+        val funnetSøknadId = søknadRepository.hentSøknadIdFraEttersendingJournalpostId("111222333", "annen-ident")
+        funnetSøknadId shouldBe null
+    }
 }
 
 fun hentSøknadbarnIdUtenÅOppretteNy(søknadId: UUID): UUID? =

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/MeldingOmEttersendingMottakTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/MeldingOmEttersendingMottakTest.kt
@@ -51,6 +51,7 @@ class MeldingOmEttersendingMottakTest {
                 any(LocalDateTime::class),
             )
         }
+        verify { søknadRepository.lagreEttersendingJournalpostId(søknadId, journalpostId) }
 
         rapidsConnection.inspektør.size shouldBe 1
         val dokumentKravInnsendtMelding = rapidsConnection.inspektør.message(0)


### PR DESCRIPTION
Legger til ny tabell ettersending_journalpost som knytter journalpostId fra ettersending-journalføring til søknadId.

SøknadsdataBehovløser slår nå opp i denne tabellen mellom den eksisterende DB-oppslaget og SAF-fallbacken, slik at ettersendinger rutes til riktig benk.

Fjerner også den midlertidige NAVe-sjekken i SafKlient fra steg 1 — ettersending-journalpostIder vil nå alltid treffes i DB-oppslaget og aldri nå SAF.