### PR TITLE
Legg til EØSPengestøtte-behovløser

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/BehovløserFactory.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/BehovløserFactory.kt
@@ -9,6 +9,7 @@ import no.nav.dagpenger.soknad.orkestrator.behov.BehovløserFactory.Behov.Bosted
 import no.nav.dagpenger.soknad.orkestrator.behov.BehovløserFactory.Behov.EgenNæringsvirksomhet
 import no.nav.dagpenger.soknad.orkestrator.behov.BehovløserFactory.Behov.EgetGårdsbruk
 import no.nav.dagpenger.soknad.orkestrator.behov.BehovløserFactory.Behov.EØSArbeid
+import no.nav.dagpenger.soknad.orkestrator.behov.BehovløserFactory.Behov.EØSPengestøtte
 import no.nav.dagpenger.soknad.orkestrator.behov.BehovløserFactory.Behov.HarTilleggsopplysninger
 import no.nav.dagpenger.soknad.orkestrator.behov.BehovløserFactory.Behov.HelseTilAlleTyperJobb
 import no.nav.dagpenger.soknad.orkestrator.behov.BehovløserFactory.Behov.JobbetUtenforNorge
@@ -36,6 +37,7 @@ import no.nav.dagpenger.soknad.orkestrator.behov.løsere.BostedslandErNorgeBehov
 import no.nav.dagpenger.soknad.orkestrator.behov.løsere.EgenNæringsvirksomhetBehovløser
 import no.nav.dagpenger.soknad.orkestrator.behov.løsere.EgetGårdsbrukBehovløser
 import no.nav.dagpenger.soknad.orkestrator.behov.løsere.EØSArbeidBehovløser
+import no.nav.dagpenger.soknad.orkestrator.behov.løsere.EØSPengestøtteBehovløser
 import no.nav.dagpenger.soknad.orkestrator.behov.løsere.HarTilleggsopplysningerBehovløser
 import no.nav.dagpenger.soknad.orkestrator.behov.løsere.HelseTilAlleTyperJobbBehovløser
 import no.nav.dagpenger.soknad.orkestrator.behov.løsere.JobbetUtenforNorgeBehovløser
@@ -221,6 +223,8 @@ class BehovløserFactory(
                 SanksjonBehovløser(rapidsConnection, opplysningRepository, søknadRepository, seksjonRepository),
             PlanleggerUtdanning to
                 PlanleggerUtdanningBehovløser(rapidsConnection, opplysningRepository, søknadRepository, seksjonRepository),
+            EØSPengestøtte to
+                EØSPengestøtteBehovløser(rapidsConnection, opplysningRepository, søknadRepository, seksjonRepository),
         )
 
     fun behovløserFor(behov: Behov): Behovløser =
@@ -256,5 +260,6 @@ class BehovløserFactory(
         BarnOver16,
         Sanksjon,
         PlanleggerUtdanning,
+        EØSPengestøtte,
     }
 }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/EØSPengestøtteBehovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/EØSPengestøtteBehovløser.kt
@@ -1,0 +1,53 @@
+package no.nav.dagpenger.soknad.orkestrator.behov.løsere
+
+import com.github.navikt.tbd_libs.rapids_and_rivers.isMissingOrNull
+import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
+import no.nav.dagpenger.soknad.orkestrator.behov.Behovløser
+import no.nav.dagpenger.soknad.orkestrator.behov.BehovløserFactory.Behov.EØSPengestøtte
+import no.nav.dagpenger.soknad.orkestrator.behov.Behovmelding
+import no.nav.dagpenger.soknad.orkestrator.config.objectMapper
+import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.asListOf
+import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.db.QuizOpplysningRepository
+import no.nav.dagpenger.soknad.orkestrator.søknad.db.SøknadRepository
+import no.nav.dagpenger.soknad.orkestrator.søknad.seksjon.SeksjonRepository
+import no.nav.dagpenger.soknad.orkestrator.utils.erBoolean
+import java.util.UUID
+
+class EØSPengestøtteBehovløser(
+    rapidsConnection: RapidsConnection,
+    opplysningRepository: QuizOpplysningRepository,
+    søknadRepository: SøknadRepository,
+    seksjonRepository: SeksjonRepository,
+) : Behovløser(rapidsConnection, opplysningRepository, søknadRepository, seksjonRepository) {
+    override val behov = EØSPengestøtte.name
+    override val beskrivendeId = "faktum.hvilke-andre-ytelser"
+
+    companion object {
+        const val EØS_DAGPENGER_SVAR = "faktum.hvilke-andre-ytelser.svar.dagpenger-annet-eos-land"
+    }
+
+    override fun løs(behovmelding: Behovmelding) {
+        val svarPåBehov = harEøsPengestøtte(behovmelding.ident, behovmelding.søknadId)
+        publiserLøsning(behovmelding, svarPåBehov)
+    }
+
+    internal fun harEøsPengestøtte(
+        ident: String,
+        søknadId: UUID,
+    ): Boolean {
+        // 1. Quiz-opplysninger (gammel søknad)
+        val quizOpplysning = opplysningRepository.hent(beskrivendeId, ident, søknadId)
+
+        if (quizOpplysning != null) {
+            return quizOpplysning.svar.asListOf<String>().contains(EØS_DAGPENGER_SVAR)
+        }
+
+        // 2. Seksjon (ny søknad)
+        val seksjonsSvar = seksjonRepository.hentSeksjonsvarEllerKastException(ident, søknadId, "annen-pengestøtte")
+
+        return objectMapper
+            .readTree(seksjonsSvar)
+            .findPath("harMottattEllerSøktOmPengestøtteFraAndreEøsLand")
+            .let { if (it.isMissingOrNull()) false else it.erBoolean() }
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/BehovløserFactoryTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/BehovløserFactoryTest.kt
@@ -83,6 +83,7 @@ class BehovløserFactoryTest {
             "BarnOver16",
             "Sanksjon",
             "PlanleggerUtdanning",
+            "EØSPengestøtte",
         )
     }
 }

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/EØSPengestøtteBehovløserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/EØSPengestøtteBehovløserTest.kt
@@ -1,0 +1,178 @@
+package no.nav.dagpenger.soknad.orkestrator.behov.løsere
+
+import com.github.navikt.tbd_libs.rapids_and_rivers.asLocalDate
+import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.dagpenger.soknad.orkestrator.behov.BehovløserFactory.Behov.EØSPengestøtte
+import no.nav.dagpenger.soknad.orkestrator.behov.løsere.EØSPengestøtteBehovløser.Companion.EØS_DAGPENGER_SVAR
+import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.QuizOpplysning
+import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.Flervalg
+import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.Tekst
+import no.nav.dagpenger.soknad.orkestrator.søknad.Søknad
+import no.nav.dagpenger.soknad.orkestrator.søknad.Tilstand
+import no.nav.dagpenger.soknad.orkestrator.søknad.db.SøknadRepository
+import no.nav.dagpenger.soknad.orkestrator.søknad.seksjon.SeksjonRepository
+import no.nav.dagpenger.soknad.orkestrator.utils.InMemoryQuizOpplysningRepository
+import java.time.ZonedDateTime
+import java.util.UUID.randomUUID
+import kotlin.test.Test
+
+class EØSPengestøtteBehovløserTest {
+    val opplysningRepository = InMemoryQuizOpplysningRepository()
+    val søknadRepository = mockk<SøknadRepository>(relaxed = true)
+    val seksjonRepository = mockk<SeksjonRepository>(relaxed = true)
+    val testRapid = TestRapid()
+    val behovløser = EØSPengestøtteBehovløser(testRapid, opplysningRepository, søknadRepository, seksjonRepository)
+    val ident = "12345678910"
+    val søknadId = randomUUID()
+
+    @Test
+    fun `skal returnere true når EØS-dagpenger-svar finnes i quiz-flervalg`() {
+        opplysningRepository.lagre(
+            QuizOpplysning(
+                beskrivendeId = behovløser.beskrivendeId,
+                type = Flervalg,
+                svar = listOf(EØS_DAGPENGER_SVAR, "faktum.hvilke-andre-ytelser.svar.noe-annet"),
+                ident = ident,
+                søknadId = søknadId,
+            ),
+        )
+
+        behovløser.harEøsPengestøtte(ident, søknadId) shouldBe true
+    }
+
+    @Test
+    fun `skal returnere false når EØS-dagpenger-svar ikke finnes i quiz-flervalg`() {
+        opplysningRepository.lagre(
+            QuizOpplysning(
+                beskrivendeId = behovløser.beskrivendeId,
+                type = Flervalg,
+                svar = listOf("faktum.hvilke-andre-ytelser.svar.noe-annet"),
+                ident = ident,
+                søknadId = søknadId,
+            ),
+        )
+
+        behovløser.harEøsPengestøtte(ident, søknadId) shouldBe false
+    }
+
+    @Test
+    fun `skal publisere løsning fra quiz-opplysning med gjelderFra`() {
+        val søknadstidspunkt = ZonedDateTime.now()
+        opplysningRepository.lagre(
+            QuizOpplysning(
+                beskrivendeId = behovløser.beskrivendeId,
+                type = Flervalg,
+                svar = listOf(EØS_DAGPENGER_SVAR),
+                ident = ident,
+                søknadId = søknadId,
+            ),
+        )
+        opplysningRepository.lagre(
+            QuizOpplysning(
+                beskrivendeId = "søknadstidspunkt",
+                type = Tekst,
+                svar = søknadstidspunkt.toString(),
+                ident = ident,
+                søknadId = søknadId,
+            ),
+        )
+
+        behovløser.løs(lagBehovmelding(ident, søknadId, EØSPengestøtte))
+
+        testRapid.inspektør.message(0)["@løsning"][EØSPengestøtte.name].also { løsning ->
+            løsning["verdi"].asBoolean() shouldBe true
+            løsning["gjelderFra"].asLocalDate() shouldBe søknadstidspunkt.toLocalDate()
+        }
+    }
+
+    @Test
+    fun `skal publisere løsning fra seksjonsdata`() {
+        val søknadstidspunkt = ZonedDateTime.now()
+        every { seksjonRepository.hentSeksjonsvarEllerKastException(any(), any(), any()) } returns
+            """
+            {
+              "seksjonId": "annen-pengestøtte",
+              "seksjonsvar": {
+                "harMottattEllerSøktOmPengestøtteFraAndreEøsLand": "ja"
+              },
+              "versjon": 1
+            }
+            """.trimIndent()
+        every { søknadRepository.hent(any()) } returns
+            Søknad(
+                søknadId = søknadId,
+                ident = ident,
+                tilstand = Tilstand.INNSENDT,
+                innsendtTidspunkt = søknadstidspunkt.toLocalDateTime(),
+            )
+
+        behovløser.løs(lagBehovmelding(ident, søknadId, EØSPengestøtte))
+
+        verify { seksjonRepository.hentSeksjonsvarEllerKastException(ident, søknadId, "annen-pengestøtte") }
+        testRapid.inspektør.message(0)["@løsning"][EØSPengestøtte.name].also { løsning ->
+            løsning["verdi"].asBoolean() shouldBe true
+            løsning["gjelderFra"].asLocalDate() shouldBe søknadstidspunkt.toLocalDate()
+        }
+    }
+
+    @Test
+    fun `skal returnere false når quiz-flervalg er tom liste`() {
+        opplysningRepository.lagre(
+            QuizOpplysning(
+                beskrivendeId = behovløser.beskrivendeId,
+                type = Flervalg,
+                svar = emptyList<String>(),
+                ident = ident,
+                søknadId = søknadId,
+            ),
+        )
+
+        behovløser.harEøsPengestøtte(ident, søknadId) shouldBe false
+    }
+
+    @Test
+    fun `skal returnere false når seksjonsdata har nei`() {
+        every { seksjonRepository.hentSeksjonsvarEllerKastException(any(), any(), any()) } returns
+            """
+            {
+              "seksjonId": "annen-pengestøtte",
+              "seksjonsvar": {
+                "harMottattEllerSøktOmPengestøtteFraAndreEøsLand": "nei"
+              },
+              "versjon": 1
+            }
+            """.trimIndent()
+
+        behovløser.harEøsPengestøtte(ident, søknadId) shouldBe false
+    }
+
+    @Test
+    fun `skal returnere false når feltet mangler i seksjonsdata`() {
+        every { seksjonRepository.hentSeksjonsvarEllerKastException(any(), any(), any()) } returns
+            """
+            {
+              "seksjonId": "annen-pengestøtte",
+              "seksjonsvar": {},
+              "versjon": 1
+            }
+            """.trimIndent()
+
+        behovløser.harEøsPengestøtte(ident, søknadId) shouldBe false
+    }
+
+    @Test
+    fun `skal kaste feil dersom seksjon mangler`() {
+        every {
+            seksjonRepository.hentSeksjonsvarEllerKastException(any(), any(), any())
+        } throws IllegalStateException("Fant ingen seksjonsvar på annen-pengestøtte for søknad=$søknadId")
+
+        shouldThrow<IllegalStateException> {
+            behovløser.løs(lagBehovmelding(ident, søknadId, EØSPengestøtte))
+        }
+    }
+}


### PR DESCRIPTION
Sjekker om bruker har mottatt eller søkt om pengestøtte fra andre EØS-land.

Quiz: faktum.hvilke-andre-ytelser (Flervalg) — returnerer true hvis faktum.hvilke-andre-ytelser.svar.dagpenger-annet-eos-land er i listen. Null fra quiz tolkes som false (spørsmålet vises ikke ved nei-svar).

Seksjon: annen-pengestøtte → harMottattEllerSøktOmPengestøtteFraAndreEøsLand