### PR TITLE
Migrer til Jackson 3 (tools.jackson)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,6 @@ val dagpengerOauth2KlientVersion: String by project
 val freemarkerVersion: String by project
 
 val junitJupiterVersion: String by project
-val naisfulTestAppVersion: String by project
 
 plugins {
     kotlin("jvm") version "2.3.21"
@@ -72,6 +71,7 @@ dependencies {
 
     implementation("io.ktor:ktor-server-netty:${libs.versions.ktor.get()}")
     implementation("io.ktor:ktor-server-config-yaml:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-server-content-negotiation:3.4.3")
 
     testImplementation(kotlin("test"))
     testImplementation(libs.ktor.client.mock)
@@ -82,5 +82,4 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion")
     testImplementation("io.ktor:ktor-server-test-host-jvm:${libs.versions.ktor.get()}")
     testImplementation(libs.rapids.and.rivers.test)
-    testImplementation("com.github.navikt.tbd-libs:naisful-test-app:$naisfulTestAppVersion")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,3 @@ dagpengerOauth2KlientVersion=2025.04.26-14.51.bbf9ece5f5ec
 freemarkerVersion=2.3.34
 
 junitJupiterVersion=5.13.2
-naisfulTestAppVersion=2025.06.20-13.05-40af2647

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 exposedVersion=0.61.0
 pamGeographyVersion=2.21
-pdlVersion=2025.04.26-14.51.bbf9ece5f5ec
+pdlVersion=2026.05.04-11.00.ccf523d33b63
 urnlibVersion=2.0.1
 prometheusMetricsCoreVersion=1.3.8
 openHtmlToPdfVersion=1.1.28

--- a/openapi/build.gradle.kts
+++ b/openapi/build.gradle.kts
@@ -24,12 +24,16 @@ sourceSets {
     }
 }
 
+kotlin {
+    jvmToolchain(21)
+}
+
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    implementation(libs.jackson.annotation)
+    implementation(libs.jackson.databind)
 }
 
 configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20251205.234.05353f")
+            from("no.nav.dagpenger:dp-version-catalog:20260518.255.1a7fc0")
         }
     }
 }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/ApplicationBuilder.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/ApplicationBuilder.kt
@@ -2,7 +2,7 @@ package no.nav.dagpenger.soknad.orkestrator
 
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.ktor.serialization.jackson.jackson
+import io.ktor.serialization.jackson3.jackson
 import io.ktor.server.application.install
 import io.ktor.server.auth.Authentication
 import io.ktor.server.auth.jwt.jwt

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/api/auth/AuthFactory.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/api/auth/AuthFactory.kt
@@ -2,7 +2,6 @@ package no.nav.dagpenger.soknad.orkestrator.api.auth
 
 import com.auth0.jwk.JwkProviderBuilder
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.DeserializationFeature
 import com.natpryce.konfig.PropertyGroup
 import com.natpryce.konfig.getValue
 import com.natpryce.konfig.stringType
@@ -11,12 +10,13 @@ import io.ktor.client.call.body
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
-import io.ktor.serialization.jackson.jackson
+import io.ktor.serialization.jackson3.jackson
 import io.ktor.server.auth.jwt.JWTAuthenticationProvider
 import io.ktor.server.auth.jwt.JWTCredential
 import io.ktor.server.auth.jwt.JWTPrincipal
 import kotlinx.coroutines.runBlocking
 import no.nav.dagpenger.soknad.orkestrator.Configuration
+import tools.jackson.databind.DeserializationFeature
 import java.net.URI
 import java.net.URL
 import java.util.concurrent.TimeUnit

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/BehovMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/BehovMottak.kt
@@ -93,6 +93,6 @@ class BehovMottak(
 }
 
 internal fun JsonMessage.mottatteBehov() =
-    get("@behov").map { it.asText() }.filter { behov ->
+    get("@behov").values().map { it.asText() }.filter { behov ->
         BehovløserFactory.Behov.entries.any { it.name == behov }
     }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/BehovMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/BehovMottak.kt
@@ -45,19 +45,19 @@ class BehovMottak(
         metadata: MessageMetadata,
         meterRegistry: MeterRegistry,
     ) {
-        val behovId = packet["@behovId"].asText()
+        val behovId = packet["@behovId"].asString()
         val søknadId =
             try {
                 packet["søknadId"].asUUID()
             } catch (e: IllegalArgumentException) {
-                logger.error(e) { "SøknadId i behovet er ikke en gyldig UUID: ${packet["søknadId"].asText()}" }
+                logger.error(e) { "SøknadId i behovet er ikke en gyldig UUID: ${packet["søknadId"].asString()}" }
                 return
             }
 
         withMDC(
             mapOf(
                 "søknadId" to søknadId.toString(),
-                "behandlingId" to packet["behandlingId"].asText(),
+                "behandlingId" to packet["behandlingId"].asString(),
                 "behovId" to behovId,
             ),
         ) {
@@ -93,6 +93,6 @@ class BehovMottak(
 }
 
 internal fun JsonMessage.mottatteBehov() =
-    get("@behov").values().map { it.asText() }.filter { behov ->
+    get("@behov").values().map { it.asString() }.filter { behov ->
         BehovløserFactory.Behov.entries.any { it.name == behov }
     }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/Behovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/Behovløser.kt
@@ -121,9 +121,9 @@ abstract class Behovløser(
         val sikkerlogg = KotlinLogging.logger("tjenestekall.Behovløser")
     }
 
-    fun JsonMessage.søknadId(): UUID = UUID.fromString(get("søknadId").asText())
+    fun JsonMessage.søknadId(): UUID = UUID.fromString(get("søknadId").asString())
 
-    fun JsonMessage.ident(): String = get("ident").asText()
+    fun JsonMessage.ident(): String = get("ident").asString()
 
     // I første omgang er gjelderFra lik søknadstidspunkt
     private fun finnGjelderFraDato(

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/Behovmelding.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/Behovmelding.kt
@@ -6,7 +6,7 @@ import no.nav.dagpenger.soknad.orkestrator.utils.asUUID
 open class Behovmelding(
     packet: JsonMessage,
 ) {
-    val behov = packet["@behov"].map { it.asText() }
+    val behov = packet["@behov"].values().map { it.asText() }
     val ident = packet["ident"].asText()
     val søknadId = packet["søknadId"].asUUID()
     val innkommendePacket: JsonMessage = packet
@@ -15,7 +15,7 @@ open class Behovmelding(
 class SøknadBehovmelding(
     packet: JsonMessage,
 ) {
-    val behov = packet["@behov"].map { it.asText() }
+    val behov = packet["@behov"].values().map { it.asText() }
     val ident = packet["ident"].asText()
     val innkommendePacket: JsonMessage = packet
 }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/Behovmelding.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/Behovmelding.kt
@@ -6,8 +6,8 @@ import no.nav.dagpenger.soknad.orkestrator.utils.asUUID
 open class Behovmelding(
     packet: JsonMessage,
 ) {
-    val behov = packet["@behov"].values().map { it.asText() }
-    val ident = packet["ident"].asText()
+    val behov = packet["@behov"].values().map { it.asString() }
+    val ident = packet["ident"].asString()
     val søknadId = packet["søknadId"].asUUID()
     val innkommendePacket: JsonMessage = packet
 }
@@ -15,7 +15,7 @@ open class Behovmelding(
 class SøknadBehovmelding(
     packet: JsonMessage,
 ) {
-    val behov = packet["@behov"].values().map { it.asText() }
-    val ident = packet["ident"].asText()
+    val behov = packet["@behov"].values().map { it.asString() }
+    val ident = packet["ident"].asString()
     val innkommendePacket: JsonMessage = packet
 }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/SøknadsdataBehovMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/SøknadsdataBehovMottak.kt
@@ -64,7 +64,7 @@ class SøknadsdataBehovMottak(
         metadata: MessageMetadata,
         meterRegistry: MeterRegistry,
     ) {
-        val behovId = packet["@behovId"].asText()
+        val behovId = packet["@behovId"].asString()
 
         withMDC(
             mapOf(

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BarnetilleggBehovLøser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BarnetilleggBehovLøser.kt
@@ -102,16 +102,16 @@ class BarnetilleggBehovLøser(
 
         val svar =
             (pdlBarn + egneBarn).map { barnJson ->
-                val kvalifisererTilBarnetillegg = barnJson["forsørgerDuBarnet"]?.asText() == "ja"
+                val kvalifisererTilBarnetillegg = barnJson["forsørgerDuBarnet"]?.asString() == "ja"
                 val fødselsdato = barnJson["fødselsdato"].asLocalDate()
                 val barnetilleggperiode = if (kvalifisererTilBarnetillegg) barnetilleggperiode(fødselsdato) else null
 
                 Løsningsbarn(
                     søknadbarnId = randomUUID(),
-                    fornavnOgMellomnavn = barnJson["fornavnOgMellomnavn"].asText(),
-                    etternavn = barnJson["etternavn"].asText(),
+                    fornavnOgMellomnavn = barnJson["fornavnOgMellomnavn"].asString(),
+                    etternavn = barnJson["etternavn"].asString(),
                     fødselsdato = fødselsdato,
-                    statsborgerskap = barnJson["bostedsland"].asText(),
+                    statsborgerskap = barnJson["bostedsland"].asString(),
                     kvalifiserer = kvalifisererTilBarnetillegg,
                     barnetilleggFom = barnetilleggperiode?.first,
                     barnetilleggTom = barnetilleggperiode?.second,

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BarnetilleggV2BehovLøser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BarnetilleggV2BehovLøser.kt
@@ -109,15 +109,15 @@ class BarnetilleggV2BehovLøser(
             }
         val svar =
             (pdlBarn + egneBarn).map { barnJson ->
-                val kvalifisererTilBarnetillegg = barnJson["forsørgerDuBarnet"]?.asText() == "ja"
+                val kvalifisererTilBarnetillegg = barnJson["forsørgerDuBarnet"]?.asString() == "ja"
                 val fødselsdato = barnJson["fødselsdato"].asLocalDate()
                 val barnetilleggperiode = if (kvalifisererTilBarnetillegg) barnetilleggperiode(fødselsdato) else null
 
                 LøsningsbarnV2(
-                    fornavnOgMellomnavn = barnJson["fornavnOgMellomnavn"].asText(),
-                    etternavn = barnJson["etternavn"].asText(),
+                    fornavnOgMellomnavn = barnJson["fornavnOgMellomnavn"].asString(),
+                    etternavn = barnJson["etternavn"].asString(),
                     fødselsdato = fødselsdato,
-                    statsborgerskap = barnJson["bostedsland"].asText(),
+                    statsborgerskap = barnJson["bostedsland"].asString(),
                     kvalifiserer = kvalifisererTilBarnetillegg,
                     barnetilleggFom = barnetilleggperiode?.first,
                     barnetilleggTom = barnetilleggperiode?.second,

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BostedslandErNorgeBehovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BostedslandErNorgeBehovløser.kt
@@ -53,7 +53,7 @@ class BostedslandErNorgeBehovløser(
 
                 seksjonsJson.findPath("bostedsland")?.let {
                     if (!it.isMissingOrNull()) {
-                        return it.asText() == "NOR"
+                        return it.asString() == "NOR"
                     }
                 }
             }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/JobbetUtenforNorgeBehovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/JobbetUtenforNorgeBehovløser.kt
@@ -52,7 +52,7 @@ class JobbetUtenforNorgeBehovløser(
             seksjonsJson.findPath("registrerteArbeidsforhold")?.let {
                 if (!it.isMissingOrNull()) {
                     return it.any { arbeidsforhold ->
-                        arbeidsforhold["hvilketLandJobbetDuI"].asText() != landkodeNorge
+                        arbeidsforhold["hvilketLandJobbetDuI"].asString() != landkodeNorge
                     }
                 }
             }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/LønnsgarantiBehovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/LønnsgarantiBehovløser.kt
@@ -54,7 +54,7 @@ class LønnsgarantiBehovløser(
             seksjonsJson.findPath("registrerteArbeidsforhold")?.let {
                 if (!it.isMissingOrNull()) {
                     return it.any { arbeidsforhold ->
-                        arbeidsforhold["hvordanHarDetteArbeidsforholdetEndretSeg"]?.asText() == "arbeidsgiverErKonkurs"
+                        arbeidsforhold["hvordanHarDetteArbeidsforholdetEndretSeg"]?.asString() == "arbeidsgiverErKonkurs"
                     }
                 }
             }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/OrdinærBehovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/OrdinærBehovløser.kt
@@ -65,7 +65,7 @@ class OrdinærBehovløser(
                     return it.any { arbeidsforhold ->
                         val hvordanHarDetteArbeidsforholdetEndretSeg = arbeidsforhold["hvordanHarDetteArbeidsforholdetEndretSeg"]
                         if (hvordanHarDetteArbeidsforholdetEndretSeg != null) {
-                            return hvordanHarDetteArbeidsforholdetEndretSeg.asText() !in ikkeOrdinæreRettighetstyper
+                            return hvordanHarDetteArbeidsforholdetEndretSeg.asString() !in ikkeOrdinæreRettighetstyper
                         }
                         return false
                     }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/PermittertBehovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/PermittertBehovløser.kt
@@ -55,7 +55,7 @@ class PermittertBehovløser(
             seksjonsJson.findPath("registrerteArbeidsforhold")?.let {
                 if (!it.isMissingOrNull()) {
                     return it.any { arbeidsforhold ->
-                        arbeidsforhold["hvordanHarDetteArbeidsforholdetEndretSeg"]?.asText() == "jegErPermittert"
+                        arbeidsforhold["hvordanHarDetteArbeidsforholdetEndretSeg"]?.asString() == "jegErPermittert"
                     }
                 }
             }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/PermittertFiskeforedlingBehovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/PermittertFiskeforedlingBehovløser.kt
@@ -54,8 +54,8 @@ class PermittertFiskeforedlingBehovløser(
                 if (!it.isMissingOrNull()) {
                     return it
                         .any { arbeidsforhold ->
-                            arbeidsforhold["hvordanHarDetteArbeidsforholdetEndretSeg"]?.asText() == "jegErPermittert" &&
-                                arbeidsforhold["permittertErDuPermittertFraFiskeforedlingsEllerFiskeoljeindustrien"]?.asText() == "ja"
+                            arbeidsforhold["hvordanHarDetteArbeidsforholdetEndretSeg"]?.asString() == "jegErPermittert" &&
+                                arbeidsforhold["permittertErDuPermittertFraFiskeforedlingsEllerFiskeoljeindustrien"]?.asString() == "ja"
                         }
                 }
             }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SanksjonBehovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SanksjonBehovløser.kt
@@ -60,7 +60,7 @@ class SanksjonBehovløser(
             seksjonsJson.findPath("registrerteArbeidsforhold")?.let {
                 if (!it.isMissingOrNull()) {
                     return it.any { arbeidsforhold ->
-                        arbeidsforhold["hvordanHarDetteArbeidsforholdetEndretSeg"]?.asText() in sanksjonSluttårsakerIOrkestrator
+                        arbeidsforhold["hvordanHarDetteArbeidsforholdetEndretSeg"]?.asString() in sanksjonSluttårsakerIOrkestrator
                     }
                 }
             }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløser.kt
@@ -42,7 +42,7 @@ class SøknadsdataBehovløser(
         }
 
         val journalpostId =
-            behovmelding.innkommendePacket.get("journalpostId").asText() ?: throw IllegalStateException(
+            behovmelding.innkommendePacket.get("journalpostId").asString() ?: throw IllegalStateException(
                 "Mangler journalpostId i behov for søknadsdata for søknaden",
             )
 
@@ -191,16 +191,16 @@ class SøknadsdataBehovløser(
         val reellArbeidssøkerSeksjon = objectMapper.readTree(seksjonsvar)
 
         val kanDuTaAlleTyperArbeid =
-            reellArbeidssøkerSeksjon.finnOpplysning("kanDuTaAlleTyperArbeid").asText() == "ja"
+            reellArbeidssøkerSeksjon.finnOpplysning("kanDuTaAlleTyperArbeid").asString() == "ja"
 
         val kanDuJobbeIHeleNorge =
-            reellArbeidssøkerSeksjon.finnOpplysning("kanDuJobbeIHeleNorge").asText() == "ja"
+            reellArbeidssøkerSeksjon.finnOpplysning("kanDuJobbeIHeleNorge").asString() == "ja"
 
         val kanDuJobbeBådeHeltidOgDeltid =
-            reellArbeidssøkerSeksjon.finnOpplysning("kanDuJobbeBådeHeltidOgDeltid").asText() == "ja"
+            reellArbeidssøkerSeksjon.finnOpplysning("kanDuJobbeBådeHeltidOgDeltid").asString() == "ja"
 
         val erDuVilligTilÅBytteYrkeEllerGåNedILønn =
-            reellArbeidssøkerSeksjon.finnOpplysning("erDuVilligTilÅBytteYrkeEllerGåNedILønn").asText() == "ja"
+            reellArbeidssøkerSeksjon.finnOpplysning("erDuVilligTilÅBytteYrkeEllerGåNedILønn").asString() == "ja"
 
         return ReellArbeidssøker(
             helse = kanDuTaAlleTyperArbeid,
@@ -241,10 +241,12 @@ class SøknadsdataBehovløser(
         val annenPengestøtteSeksjon = objectMapper.readTree(seksjonsvar)
 
         val mottarDuPengestøtteFraAndreEnnNav: Boolean =
-            annenPengestøtteSeksjon.finnOpplysning("mottarDuPengestøtteFraAndreEnnNav").asText() == "ja"
+            annenPengestøtteSeksjon.finnOpplysning("mottarDuPengestøtteFraAndreEnnNav").asString() == "ja"
 
         val mottarDuAndreUtbetalingerEllerØkonomiskeGoderFraTidligereArbeidsgiver =
-            annenPengestøtteSeksjon.finnOpplysning("mottarDuAndreUtbetalingerEllerØkonomiskeGoderFraTidligereArbeidsgiver").asText() == "ja"
+            annenPengestøtteSeksjon
+                .finnOpplysning("mottarDuAndreUtbetalingerEllerØkonomiskeGoderFraTidligereArbeidsgiver")
+                .asString() == "ja"
 
         return mottarDuPengestøtteFraAndreEnnNav ||
             mottarDuAndreUtbetalingerEllerØkonomiskeGoderFraTidligereArbeidsgiver
@@ -335,7 +337,7 @@ class SøknadsdataBehovløser(
                     AvsluttedeArbeidsforhold(
                         sluttårsak = arbeidsforhold.sluttårsak(),
                         fiskeforedling = arbeidsforhold.fiskForedling(),
-                        land = arbeidsforhold.findPath("hvilketLandJobbetDuI").asText(),
+                        land = arbeidsforhold.findPath("hvilketLandJobbetDuI").asString(),
                     )
                 }
             }
@@ -349,7 +351,7 @@ class SøknadsdataBehovløser(
             ?: throw NoSuchElementException("Finner ikke opplysning med navn: $navn")
 
     private fun JsonNode.sluttårsak(): Sluttårsak =
-        this.findPath("hvordanHarDetteArbeidsforholdetEndretSeg").asText().let {
+        this.findPath("hvordanHarDetteArbeidsforholdetEndretSeg").asString().let {
             mapSluttÅrsak(it)
         }
 
@@ -368,7 +370,7 @@ class SøknadsdataBehovløser(
 
     private fun JsonNode.fiskForedling(): Boolean {
         val node = this.findPath("permittertErDuPermittertFraFiskeforedlingsEllerFiskeoljeindustrien")
-        return !node.isMissingNode && !node.isNull && node.asText() == "ja"
+        return !node.isMissingNode && !node.isNull && node.asString() == "ja"
     }
 
     private fun finnSluttÅrsakForQuiz(sluttårsak: Sluttårsak): Sluttårsak {
@@ -400,10 +402,10 @@ class SøknadsdataBehovløser(
         val personaliaSeksjonsData = objectMapper.readTree(seksjonsSvar)
         // Feltet finnes bare hvis bruker er folkeregistrert i Norge (landFraPdl === "NORGE").
         // Brukere uten norsk folkeregistrert adresse får aldri spørsmålet, så manglende felt er forventet.
-        val borINorge = personaliaSeksjonsData.findPath("folkeregistrertAdresseErNorgeStemmerDet").asText()
+        val borINorge = personaliaSeksjonsData.findPath("folkeregistrertAdresseErNorgeStemmerDet").asString()
         if (borINorge == "ja") return false
 
-        val bostedsland = personaliaSeksjonsData.finnOpplysning("bostedsland").asText()
+        val bostedsland = personaliaSeksjonsData.finnOpplysning("bostedsland").asString()
         return eøsLandOgSveits.contains(bostedsland)
     }
 

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløser.kt
@@ -1,8 +1,6 @@
 package no.nav.dagpenger.soknad.orkestrator.behov.løsere
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.isMissingOrNull
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import no.nav.dagpenger.soknad.orkestrator.behov.Behovløser
@@ -20,6 +18,8 @@ import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.db.QuizOpplysningRepos
 import no.nav.dagpenger.soknad.orkestrator.saf.SafKlient
 import no.nav.dagpenger.soknad.orkestrator.søknad.db.SøknadRepository
 import no.nav.dagpenger.soknad.orkestrator.søknad.seksjon.SeksjonRepository
+import tools.jackson.core.type.TypeReference
+import tools.jackson.databind.JsonNode
 import java.time.LocalDate
 import java.util.UUID
 
@@ -271,14 +271,14 @@ class SøknadsdataBehovløser(
             )
 
         val pdlBarn =
-            objectMapper.readTree(seksjonsvar).let { seksjonJson ->
-                seksjonJson.findPath("barnFraPdl")?.toList() ?: emptyList()
-            }
+            objectMapper.readTree(seksjonsvar)?.let { seksjonJson ->
+                seksjonJson.findPath("barnFraPdl").takeUnless { it.isMissingNode }?.toList() ?: emptyList()
+            } ?: emptyList()
 
         val egneBarn =
-            objectMapper.readTree(seksjonsvar).let { seksjonJson ->
-                seksjonJson.findPath("barnLagtManuelt")?.toList() ?: emptyList()
-            }
+            objectMapper.readTree(seksjonsvar)?.let { seksjonJson ->
+                seksjonJson.findPath("barnLagtManuelt").takeUnless { it.isMissingNode }?.toList() ?: emptyList()
+            } ?: emptyList()
 
         return !(pdlBarn.isEmpty() && egneBarn.isEmpty())
     }
@@ -329,16 +329,14 @@ class SøknadsdataBehovløser(
                 return emptyList()
             }
 
-        objectMapper.readTree(seksjonsSvar).let { seksjonsJson ->
-            seksjonsJson.findPath("registrerteArbeidsforhold")?.let {
-                if (!it.isMissingOrNull()) {
-                    return it.map {
-                        AvsluttedeArbeidsforhold(
-                            sluttårsak = it.sluttårsak(),
-                            fiskeforedling = it.fiskForedling(),
-                            land = it.findPath("hvilketLandJobbetDuI").asText(),
-                        )
-                    }
+        objectMapper.readTree(seksjonsSvar)?.let { seksjonsJson ->
+            seksjonsJson.findPath("registrerteArbeidsforhold").takeUnless { it.isMissingOrNull() }?.let { arbeidsforholdNode ->
+                return arbeidsforholdNode.values().map { arbeidsforhold ->
+                    AvsluttedeArbeidsforhold(
+                        sluttårsak = arbeidsforhold.sluttårsak(),
+                        fiskeforedling = arbeidsforhold.fiskForedling(),
+                        land = arbeidsforhold.findPath("hvilketLandJobbetDuI").asText(),
+                    )
                 }
             }
         }
@@ -347,7 +345,8 @@ class SøknadsdataBehovløser(
     }
 
     private fun JsonNode.finnOpplysning(navn: String): JsonNode =
-        this.findPath(navn) ?: throw NoSuchElementException("Finner ikke opplysning med navn: $navn")
+        this.findPath(navn).takeUnless { it.isMissingNode }
+            ?: throw NoSuchElementException("Finner ikke opplysning med navn: $navn")
 
     private fun JsonNode.sluttårsak(): Sluttårsak =
         this.findPath("hvordanHarDetteArbeidsforholdetEndretSeg").asText().let {
@@ -367,8 +366,10 @@ class SøknadsdataBehovløser(
             else -> throw IllegalArgumentException("Ukjent sluttårsak: $string")
         }
 
-    private fun JsonNode.fiskForedling(): Boolean =
-        this.finnOpplysning("permittertErDuPermittertFraFiskeforedlingsEllerFiskeoljeindustrien").asText() == "ja"
+    private fun JsonNode.fiskForedling(): Boolean {
+        val node = this.findPath("permittertErDuPermittertFraFiskeforedlingsEllerFiskeoljeindustrien")
+        return !node.isMissingNode && !node.isNull && node.asText() == "ja"
+    }
 
     private fun finnSluttÅrsakForQuiz(sluttårsak: Sluttårsak): Sluttårsak {
         if (sluttårsak == Sluttårsak.PERMITTERT_FISKEFOREDLING) {
@@ -397,7 +398,9 @@ class SøknadsdataBehovløser(
             )
 
         val personaliaSeksjonsData = objectMapper.readTree(seksjonsSvar)
-        val borINorge = personaliaSeksjonsData.finnOpplysning("folkeregistrertAdresseErNorgeStemmerDet").asText()
+        // Feltet finnes bare hvis bruker er folkeregistrert i Norge (landFraPdl === "NORGE").
+        // Brukere uten norsk folkeregistrert adresse får aldri spørsmålet, så manglende felt er forventet.
+        val borINorge = personaliaSeksjonsData.findPath("folkeregistrertAdresseErNorgeStemmerDet").asText()
         if (borINorge == "ja") return false
 
         val bostedsland = personaliaSeksjonsData.finnOpplysning("bostedsland").asText()

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/config/ObjectMapper.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/config/ObjectMapper.kt
@@ -1,24 +1,23 @@
 package no.nav.dagpenger.soknad.orkestrator.config
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.KotlinModule
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.cfg.DateTimeFeature
+import tools.jackson.databind.introspect.DefaultAccessorNamingStrategy
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.jacksonMapperBuilder
 
-fun ObjectMapper.configure() =
-    this.apply {
-        registerModules(
-            KotlinModule
-                .Builder()
-                .withReflectionCacheSize(512)
-                .build(),
-        )
+val objectMapper: ObjectMapper =
+    jacksonMapperBuilder()
+        .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .accessorNaming(DefaultAccessorNamingStrategy.Provider().withFirstCharAcceptance(true, true))
+        .build()
 
-        registerModules(JavaTimeModule())
-        configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
-        configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-    }
-
-val objectMapper = ObjectMapper().configure()
+fun JsonMapper.Builder.configure() {
+    enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+    accessorNaming(DefaultAccessorNamingStrategy.Provider().withFirstCharAcceptance(true, true))
+}

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/journalføring/MinidialogJournalførtMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/journalføring/MinidialogJournalførtMottak.kt
@@ -50,9 +50,9 @@ internal class MinidialogJournalførtMottak(
         metadata: MessageMetadata,
         meterRegistry: MeterRegistry,
     ) {
-        val behovId = packet["@behovId"].asText()
-        val søknadId = packet["søknad_uuid"].asText()
-        val dialogId = packet[behov]["dialog_uuid"].asText()
+        val behovId = packet["@behovId"].asString()
+        val søknadId = packet["søknad_uuid"].asString()
+        val dialogId = packet[behov]["dialog_uuid"].asString()
         val journalpostId = packet["@løsning"][behov].asLong()
 
         withLoggingContext(
@@ -60,7 +60,7 @@ internal class MinidialogJournalførtMottak(
             "søknadId" to søknadId,
             "dialogId" to dialogId,
         ) {
-            if (packet["@id"].asText() in emptyList<String>()) {
+            if (packet["@id"].asString() in emptyList<String>()) {
                 logger.warn {
                     "Ignorerer melding fordi den inneholder en duplikat journalføring journalpostId=$journalpostId"
                 }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/land/Landoppslag.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/land/Landoppslag.kt
@@ -1,7 +1,7 @@
 package no.nav.dagpenger.soknad.orkestrator.land
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.nav.dagpenger.soknad.orkestrator.api.models.LandDTO
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import java.io.FileNotFoundException
 
 internal object Landoppslag {
@@ -18,7 +18,7 @@ internal object Landoppslag {
     }
 
     val land =
-        world.let { mapper.readTree(it) }.map {
+        world.let { mapper.readTree(it) }.values().map {
             val alpha3Code = it["alpha3"].asText()
             require(alpha3Code.length == 3) {
                 "ISO 3166-1-alpha3 må være 3 bokstaver lang. Fikk: $alpha3Code"

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/land/Landoppslag.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/land/Landoppslag.kt
@@ -19,12 +19,12 @@ internal object Landoppslag {
 
     val land =
         world.let { mapper.readTree(it) }.values().map {
-            val alpha3Code = it["alpha3"].asText()
+            val alpha3Code = it["alpha3"].asString()
             require(alpha3Code.length == 3) {
                 "ISO 3166-1-alpha3 må være 3 bokstaver lang. Fikk: $alpha3Code"
             }
             val landkode = alpha3Code.uppercase()
-            val landnavn = it["no"].asText()
+            val landnavn = it["no"].asString()
 
             LandDTO(
                 alpha3kode = landkode,

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/OpplysningService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/OpplysningService.kt
@@ -72,16 +72,16 @@ class OpplysningService(
         val egneBarn = seksjonJson.findPath("barnLagtManuelt")?.toList() ?: emptyList()
 
         fun JsonNode.tilBarnSvar(fraRegister: Boolean): BarnSvar {
-            val kvalifiserer = this["forsørgerDuBarnet"]?.asText() == "ja"
+            val kvalifiserer = this["forsørgerDuBarnet"]?.asString() == "ja"
             val fødselsdato = this["fødselsdato"].asLocalDate()
             val barnetilleggperiode = if (kvalifiserer) barnetilleggperiode(fødselsdato) else null
 
             return BarnSvar(
-                barnSvarId = this["id"]?.asText()?.let { UUID.fromString(it) } ?: UUID.randomUUID(),
-                fornavnOgMellomnavn = this["fornavnOgMellomnavn"].asText(),
-                etternavn = this["etternavn"].asText(),
+                barnSvarId = this["id"]?.asString()?.let { UUID.fromString(it) } ?: UUID.randomUUID(),
+                fornavnOgMellomnavn = this["fornavnOgMellomnavn"].asString(),
+                etternavn = this["etternavn"].asString(),
                 fødselsdato = fødselsdato,
-                statsborgerskap = this["bostedsland"].asText(),
+                statsborgerskap = this["bostedsland"].asString(),
                 forsørgerBarnet = kvalifiserer,
                 fraRegister = fraRegister,
                 kvalifisererTilBarnetillegg = kvalifiserer,

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/OpplysningService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/OpplysningService.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.soknad.orkestrator.opplysning
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.asLocalDate
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.dagpenger.soknad.orkestrator.api.models.BarnDataDTO
@@ -21,6 +20,7 @@ import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.BarnSvar
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.db.QuizOpplysningRepository
 import no.nav.dagpenger.soknad.orkestrator.søknad.db.SøknadRepository
 import no.nav.dagpenger.soknad.orkestrator.søknad.seksjon.SeksjonRepository
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 class OpplysningService(

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/SaksbehandlerBarnRepositoryPostgres.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/SaksbehandlerBarnRepositoryPostgres.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.soknad.orkestrator.opplysning
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.dagpenger.soknad.orkestrator.config.objectMapper
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.BarnSvar
 import org.jetbrains.exposed.sql.Database
@@ -8,6 +7,7 @@ import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
+import tools.jackson.module.kotlin.readValue
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/KontonummerService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/personalia/KontonummerService.kt
@@ -1,8 +1,5 @@
 package no.nav.dagpenger.soknad.orkestrator.personalia
 
-import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
-import com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -18,7 +15,8 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders.Accept
 import io.ktor.http.HttpHeaders.Authorization
 import io.ktor.http.HttpStatusCode.Companion.NotFound
-import io.ktor.serialization.jackson.jackson
+import io.ktor.serialization.jackson3.jackson
+import no.nav.dagpenger.soknad.orkestrator.config.configure
 
 private val logger = KotlinLogging.logger {}
 
@@ -34,11 +32,7 @@ class KontonummerService(
                 level = INFO
             }
             install(ContentNegotiation) {
-                jackson {
-                    registerModule(JavaTimeModule())
-                    configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-                    disable(WRITE_DATES_AS_TIMESTAMPS)
-                }
+                jackson { configure() }
             }
         }
 

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Arbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Arbeidsforhold.kt
@@ -61,14 +61,14 @@ data object Arbeidsforhold : Datatype<List<ArbeidsforholdSvar>>(
                     .values()
                     .single { it.get("beskrivendeId")?.textValue() == "faktum.arbeidsforhold.navn-bedrift" }
                     .get("svar")
-                    .asText()
+                    .asString()
 
             val landFaktum =
                 arbeidsforhold
                     .values()
                     .single { it.get("beskrivendeId")?.textValue() == "faktum.arbeidsforhold.land" }
                     .get("svar")
-                    .asText()
+                    .asString()
 
             val sluttårsak = finnSluttårsak(arbeidsforhold)
 
@@ -84,7 +84,7 @@ data object Arbeidsforhold : Datatype<List<ArbeidsforholdSvar>>(
             .values()
             .single { it.get("beskrivendeId")?.textValue() == "faktum.arbeidsforhold.endret" }
             .get("svar")
-            .asText()
+            .asString()
             .let {
                 when (it) {
                     "faktum.arbeidsforhold.endret.svar.arbeidsgiver-konkurs" -> ARBEIDSGIVER_KONKURS

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Arbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Arbeidsforhold.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper
 
-import com.fasterxml.jackson.databind.JsonNode
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.QuizOpplysning
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.Sluttårsak.ARBEIDSGIVER_KONKURS
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.Sluttårsak.AVSKJEDIGET
@@ -9,6 +8,7 @@ import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.Sluttårsak.
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.Sluttårsak.REDUSERT_ARBEIDSTID
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.Sluttårsak.SAGT_OPP_AV_ARBEIDSGIVER
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.Sluttårsak.SAGT_OPP_SELV
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 @Suppress("UNCHECKED_CAST")
@@ -21,7 +21,7 @@ data object Arbeidsforhold : Datatype<List<ArbeidsforholdSvar>>(
         ident: String,
         søknadId: UUID,
     ): QuizOpplysning<*>? {
-        val kompletteArbeidsforhold = faktum["svar"].filter { harAllePåkrevdeFelt(it) }
+        val kompletteArbeidsforhold = faktum["svar"].values().filter { harAllePåkrevdeFelt(it) }
 
         if (kompletteArbeidsforhold.isEmpty()) return null
 
@@ -46,21 +46,27 @@ data object Arbeidsforhold : Datatype<List<ArbeidsforholdSvar>>(
     }
 
     private fun erPermittering(arbeidsforhold: JsonNode) =
-        arbeidsforhold.any { it["svar"].asText() == "faktum.arbeidsforhold.endret.svar.permittert" }
+        arbeidsforhold.values().any {
+            it["svar"]?.takeIf { node -> node.isTextual }?.textValue() ==
+                "faktum.arbeidsforhold.endret.svar.permittert"
+        }
 
-    private fun JsonNode.harPåkrevdFelt(påkrevdFelt: String): Boolean = this.any { it["beskrivendeId"].asText() == påkrevdFelt }
+    private fun JsonNode.harPåkrevdFelt(påkrevdFelt: String): Boolean =
+        this.values().any { it["beskrivendeId"]?.takeIf { node -> node.isTextual }?.textValue() == påkrevdFelt }
 
     private fun hentArbeidsforholdSvar(kompletteArbeidsforhold: List<JsonNode>) =
         kompletteArbeidsforhold.map { arbeidsforhold ->
             val navnSvar =
                 arbeidsforhold
-                    .single { it.get("beskrivendeId").asText() == "faktum.arbeidsforhold.navn-bedrift" }
+                    .values()
+                    .single { it.get("beskrivendeId")?.textValue() == "faktum.arbeidsforhold.navn-bedrift" }
                     .get("svar")
                     .asText()
 
             val landFaktum =
                 arbeidsforhold
-                    .single { it.get("beskrivendeId").asText() == "faktum.arbeidsforhold.land" }
+                    .values()
+                    .single { it.get("beskrivendeId")?.textValue() == "faktum.arbeidsforhold.land" }
                     .get("svar")
                     .asText()
 
@@ -75,7 +81,8 @@ data object Arbeidsforhold : Datatype<List<ArbeidsforholdSvar>>(
 
     internal fun finnSluttårsak(arbeidsforhold: JsonNode): Sluttårsak =
         arbeidsforhold
-            .single { it.get("beskrivendeId").asText() == "faktum.arbeidsforhold.endret" }
+            .values()
+            .single { it.get("beskrivendeId")?.textValue() == "faktum.arbeidsforhold.endret" }
             .get("svar")
             .asText()
             .let {
@@ -94,8 +101,8 @@ data object Arbeidsforhold : Datatype<List<ArbeidsforholdSvar>>(
 
     private fun finnSluttårsakVedPermittering(arbeidsforhold: JsonNode): Sluttårsak {
         val permittertFraFiskeriFaktum =
-            arbeidsforhold.single {
-                it.get("beskrivendeId").asText() == "faktum.arbeidsforhold.permittertert-fra-fiskeri-naering"
+            arbeidsforhold.values().single {
+                it.get("beskrivendeId")?.textValue() == "faktum.arbeidsforhold.permittertert-fra-fiskeri-naering"
             }
 
         return when (permittertFraFiskeriFaktum.get("svar").asBoolean()) {

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Barn.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Barn.kt
@@ -1,8 +1,8 @@
 package no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.asLocalDate
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.QuizOpplysning
+import tools.jackson.databind.JsonNode
 import java.time.LocalDate
 import java.util.UUID
 
@@ -17,29 +17,34 @@ data object Barn : Datatype<List<BarnSvar>>(List::class.java as Class<List<BarnS
         val fraRegister = beskrivendeId == "faktum.register.barn-liste"
 
         val barnSvar: List<BarnSvar> =
-            faktum.get("svar").map { it ->
+            faktum.get("svar").values().map { it ->
                 val fornavnOgMellomnavn =
                     it
+                        .values()
                         .single { it.get("beskrivendeId").asText() == "faktum.barn-fornavn-mellomnavn" }
                         .get("svar")
                         .asText()
                 val etternavn =
                     it
+                        .values()
                         .single { it.get("beskrivendeId").asText() == "faktum.barn-etternavn" }
                         .get("svar")
                         .asText()
                 val fødselsdato =
                     it
+                        .values()
                         .single { it.get("beskrivendeId").asText() == "faktum.barn-foedselsdato" }
                         .get("svar")
                         .asLocalDate()
                 val statsborgerskap =
                     it
+                        .values()
                         .single { it.get("beskrivendeId").asText() == "faktum.barn-statsborgerskap" }
                         .get("svar")
                         .asText()
                 val forsørgerBarnet =
                     it
+                        .values()
                         .single { it.get("beskrivendeId").asText() == "faktum.forsoerger-du-barnet" }
                         .get("svar")
                         .asBoolean()

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Barn.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Barn.kt
@@ -21,31 +21,31 @@ data object Barn : Datatype<List<BarnSvar>>(List::class.java as Class<List<BarnS
                 val fornavnOgMellomnavn =
                     it
                         .values()
-                        .single { it.get("beskrivendeId").asText() == "faktum.barn-fornavn-mellomnavn" }
+                        .single { it.get("beskrivendeId").asString() == "faktum.barn-fornavn-mellomnavn" }
                         .get("svar")
-                        .asText()
+                        .asString()
                 val etternavn =
                     it
                         .values()
-                        .single { it.get("beskrivendeId").asText() == "faktum.barn-etternavn" }
+                        .single { it.get("beskrivendeId").asString() == "faktum.barn-etternavn" }
                         .get("svar")
-                        .asText()
+                        .asString()
                 val fødselsdato =
                     it
                         .values()
-                        .single { it.get("beskrivendeId").asText() == "faktum.barn-foedselsdato" }
+                        .single { it.get("beskrivendeId").asString() == "faktum.barn-foedselsdato" }
                         .get("svar")
                         .asLocalDate()
                 val statsborgerskap =
                     it
                         .values()
-                        .single { it.get("beskrivendeId").asText() == "faktum.barn-statsborgerskap" }
+                        .single { it.get("beskrivendeId").asString() == "faktum.barn-statsborgerskap" }
                         .get("svar")
-                        .asText()
+                        .asString()
                 val forsørgerBarnet =
                     it
                         .values()
-                        .single { it.get("beskrivendeId").asText() == "faktum.forsoerger-du-barnet" }
+                        .single { it.get("beskrivendeId").asString() == "faktum.forsoerger-du-barnet" }
                         .get("svar")
                         .asBoolean()
 

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Boolsk.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Boolsk.kt
@@ -1,7 +1,7 @@
 package no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper
 
-import com.fasterxml.jackson.databind.JsonNode
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.QuizOpplysning
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 data object Boolsk : Datatype<Boolean>(Boolean::class.java) {

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Datatype.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Datatype.kt
@@ -1,7 +1,7 @@
 package no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper
 
-import com.fasterxml.jackson.databind.JsonNode
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.QuizOpplysning
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 sealed class Datatype<T>(

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Dato.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Dato.kt
@@ -1,8 +1,8 @@
 package no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.asLocalDate
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.QuizOpplysning
+import tools.jackson.databind.JsonNode
 import java.time.LocalDate
 import java.util.UUID
 

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Desimaltall.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Desimaltall.kt
@@ -1,7 +1,7 @@
 package no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper
 
-import com.fasterxml.jackson.databind.JsonNode
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.QuizOpplysning
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 data object Desimaltall : Datatype<Double>(Double::class.java) {

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/EgenNæring.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/EgenNæring.kt
@@ -1,7 +1,7 @@
 package no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper
 
-import com.fasterxml.jackson.databind.JsonNode
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.QuizOpplysning
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 @Suppress("UNCHECKED_CAST")

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/EøsArbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/EøsArbeidsforhold.kt
@@ -1,8 +1,8 @@
 package no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.asLocalDate
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.QuizOpplysning
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 @Suppress("UNCHECKED_CAST")
@@ -16,27 +16,31 @@ data object EøsArbeidsforhold : Datatype<List<EøsArbeidsforholdSvar>>(
         søknadId: UUID,
     ): QuizOpplysning<*> {
         val eøsArbeidsforholdSvar: List<EøsArbeidsforholdSvar> =
-            faktum.get("svar").map { eøsArbeidsforhold ->
+            faktum.get("svar").values().map { eøsArbeidsforhold ->
                 val arbeidsgivernavnSvar =
                     eøsArbeidsforhold
+                        .values()
                         .find { it.get("beskrivendeId").asText() == "faktum.eos-arbeidsforhold.arbeidsgivernavn" }
                         ?.get("svar")
                         ?.asText() ?: ""
 
                 val landSvar =
                     eøsArbeidsforhold
+                        .values()
                         .find { it.get("beskrivendeId").asText() == "faktum.eos-arbeidsforhold.land" }
                         ?.get("svar")
                         ?.asText() ?: ""
 
                 val personnummerSvar =
                     eøsArbeidsforhold
+                        .values()
                         .find { it.get("beskrivendeId").asText() == "faktum.eos-arbeidsforhold.personnummer" }
                         ?.get("svar")
                         ?.asText() ?: ""
 
                 val varighet =
                     eøsArbeidsforhold
+                        .values()
                         .find { it.get("beskrivendeId").asText() == "faktum.eos-arbeidsforhold.varighet" }
                         ?.get("svar")
 

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/EøsArbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/EøsArbeidsforhold.kt
@@ -20,28 +20,28 @@ data object EøsArbeidsforhold : Datatype<List<EøsArbeidsforholdSvar>>(
                 val arbeidsgivernavnSvar =
                     eøsArbeidsforhold
                         .values()
-                        .find { it.get("beskrivendeId").asText() == "faktum.eos-arbeidsforhold.arbeidsgivernavn" }
+                        .find { it.get("beskrivendeId").asString() == "faktum.eos-arbeidsforhold.arbeidsgivernavn" }
                         ?.get("svar")
-                        ?.asText() ?: ""
+                        ?.asString() ?: ""
 
                 val landSvar =
                     eøsArbeidsforhold
                         .values()
-                        .find { it.get("beskrivendeId").asText() == "faktum.eos-arbeidsforhold.land" }
+                        .find { it.get("beskrivendeId").asString() == "faktum.eos-arbeidsforhold.land" }
                         ?.get("svar")
-                        ?.asText() ?: ""
+                        ?.asString() ?: ""
 
                 val personnummerSvar =
                     eøsArbeidsforhold
                         .values()
-                        .find { it.get("beskrivendeId").asText() == "faktum.eos-arbeidsforhold.personnummer" }
+                        .find { it.get("beskrivendeId").asString() == "faktum.eos-arbeidsforhold.personnummer" }
                         ?.get("svar")
-                        ?.asText() ?: ""
+                        ?.asString() ?: ""
 
                 val varighet =
                     eøsArbeidsforhold
                         .values()
-                        .find { it.get("beskrivendeId").asText() == "faktum.eos-arbeidsforhold.varighet" }
+                        .find { it.get("beskrivendeId").asString() == "faktum.eos-arbeidsforhold.varighet" }
                         ?.get("svar")
 
                 val fom = varighet?.get("fom")?.asLocalDate() ?: throw IllegalArgumentException("Fom dato mangler")

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Flervalg.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Flervalg.kt
@@ -1,7 +1,7 @@
 package no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper
 
-import com.fasterxml.jackson.databind.JsonNode
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.QuizOpplysning
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 @Suppress("UNCHECKED_CAST")
@@ -12,7 +12,7 @@ data object Flervalg : Datatype<List<String>>(String::class.java as Class<List<S
         ident: String,
         søknadId: UUID,
     ): QuizOpplysning<*> {
-        val svar = faktum.get("svar").map { it.asText() }
+        val svar = faktum.get("svar").values().map { it.asText() }
         return QuizOpplysning(beskrivendeId, Flervalg, svar, ident, søknadId)
     }
 }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Flervalg.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Flervalg.kt
@@ -12,7 +12,7 @@ data object Flervalg : Datatype<List<String>>(String::class.java as Class<List<S
         ident: String,
         søknadId: UUID,
     ): QuizOpplysning<*> {
-        val svar = faktum.get("svar").values().map { it.asText() }
+        val svar = faktum.get("svar").values().map { it.asString() }
         return QuizOpplysning(beskrivendeId, Flervalg, svar, ident, søknadId)
     }
 }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Heltall.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Heltall.kt
@@ -1,7 +1,7 @@
 package no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper
 
-import com.fasterxml.jackson.databind.JsonNode
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.QuizOpplysning
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 data object Heltall : Datatype<Int>(Int::class.java) {

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Periode.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Periode.kt
@@ -1,8 +1,8 @@
 package no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.asLocalDate
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.QuizOpplysning
+import tools.jackson.databind.JsonNode
 import java.time.LocalDate
 import java.util.UUID
 

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Tekst.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Tekst.kt
@@ -11,7 +11,7 @@ data object Tekst : Datatype<String>(String::class.java) {
         ident: String,
         søknadId: UUID,
     ): QuizOpplysning<*> {
-        val svar = faktum.get("svar").asText()
+        val svar = faktum.get("svar").asString()
         return QuizOpplysning(beskrivendeId, Tekst, svar, ident, søknadId)
     }
 }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Tekst.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatyper/Tekst.kt
@@ -1,7 +1,7 @@
 package no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper
 
-import com.fasterxml.jackson.databind.JsonNode
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.QuizOpplysning
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 data object Tekst : Datatype<String>(String::class.java) {

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/NyJournalpost.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/NyJournalpost.kt
@@ -40,7 +40,7 @@ data class Dokumentvariant(
 fun JsonNode.dokumentVarianter(): List<Dokumentvariant> =
     this.toList().map { node ->
         val format =
-            when (node["metainfo"]["variant"].asText()) {
+            when (node["metainfo"]["variant"].asString()) {
                 "NETTO" -> {
                     "ARKIV"
                 }
@@ -56,9 +56,9 @@ fun JsonNode.dokumentVarianter(): List<Dokumentvariant> =
                 }
             }
         Dokumentvariant(
-            filnavn = node["metainfo"]["innhold"].asText(),
-            urn = node["urn"].asText(),
+            filnavn = node["metainfo"]["innhold"].asString(),
+            urn = node["urn"].asString(),
             variant = format,
-            type = node["metainfo"]["filtype"].asText(),
+            type = node["metainfo"]["filtype"].asString(),
         )
     }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/NyJournalpost.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/NyJournalpost.kt
@@ -1,7 +1,7 @@
 package no.nav.dagpenger.soknad.orkestrator.søknad
 
-import com.fasterxml.jackson.databind.JsonNode
 import de.slub.urn.URN
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 data class NyJournalpost(

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadMapper.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadMapper.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.soknad.orkestrator.søknad
 
-import com.fasterxml.jackson.databind.JsonNode
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.dagpenger.soknad.orkestrator.metrikker.SøknadMetrikker
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.QuizOpplysning
@@ -17,6 +16,7 @@ import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.Heltall
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.Periode
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.Tekst
 import no.nav.dagpenger.soknad.orkestrator.utils.asUUID
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 class SøknadMapper(

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadMapper.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadMapper.kt
@@ -23,10 +23,10 @@ class SøknadMapper(
     private val jsonNode: JsonNode,
 ) {
     val søknad by lazy {
-        val ident = jsonNode.get("ident").asText()
+        val ident = jsonNode.get("ident").asString()
         val søknadId = jsonNode.get("søknadId").asUUID()
         val søknadData = jsonNode.get("søknadData")
-        val søknadstidspunkt = jsonNode.get("søknadstidspunkt").asText()
+        val søknadstidspunkt = jsonNode.get("søknadstidspunkt").asString()
 
         Søknad(
             søknadId = søknadId,
@@ -80,8 +80,8 @@ class SøknadMapper(
         ident: String,
         søknadId: UUID,
     ): QuizOpplysning<*>? {
-        val beskrivendeId = faktum.get("beskrivendeId").asText()
-        val faktumtype = faktum.get("type").asText()
+        val beskrivendeId = faktum.get("beskrivendeId").asString()
+        val faktumtype = faktum.get("type").asString()
 
         if (faktumtype == "dokument") {
             return null

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadService.kt
@@ -279,7 +279,7 @@ class SøknadService(
             seksjonsJson.findPath("registrerteArbeidsforhold")?.let {
                 if (!it.isMissingOrNull()) {
                     return it.any { arbeidsforhold ->
-                        arbeidsforhold["hvordanHarDetteArbeidsforholdetEndretSeg"]?.asText() == "jegErPermittert"
+                        arbeidsforhold["hvordanHarDetteArbeidsforholdetEndretSeg"]?.asString() == "jegErPermittert"
                     }
                 }
             }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadService.kt
@@ -1,8 +1,5 @@
 package no.nav.dagpenger.soknad.orkestrator.søknad
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.json.JsonMapper
-import com.fasterxml.jackson.databind.node.ObjectNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.isMissingOrNull
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -16,6 +13,9 @@ import no.nav.dagpenger.soknad.orkestrator.søknad.melding.MeldingOmSøknadSlett
 import no.nav.dagpenger.soknad.orkestrator.søknad.melding.SøknadEndretTilstandMelding
 import no.nav.dagpenger.soknad.orkestrator.søknad.seksjon.SeksjonRepository
 import no.nav.dagpenger.soknad.orkestrator.utils.erBoolean
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.databind.node.ObjectNode
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -47,7 +47,7 @@ class SøknadService(
             objectMapper.createObjectNode().apply {
                 put("ident", ident)
                 put("søknadId", søknadId.toString())
-                set<JsonNode>("seksjoner", seksjoner)
+                set("seksjoner", seksjoner)
             }
 
         søknadRepository.lagreKomplettSøknadData(søknadId, komplettSøknaddata)

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/db/SøknadRepository.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/db/SøknadRepository.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.soknad.orkestrator.søknad.db
 
-import com.fasterxml.jackson.databind.JsonNode
 import no.nav.dagpenger.soknad.orkestrator.config.objectMapper
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.db.QuizOpplysningRepository
 import no.nav.dagpenger.soknad.orkestrator.søknad.Søknad
@@ -33,6 +32,7 @@ import org.jetbrains.exposed.sql.stringLiteral
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
 import org.jetbrains.exposed.sql.upsert
+import tools.jackson.databind.JsonNode
 import java.time.LocalDateTime
 import java.time.LocalDateTime.now
 import java.util.UUID

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/melding/DokumentKravInnsendtMelding.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/melding/DokumentKravInnsendtMelding.kt
@@ -32,6 +32,10 @@ class DokumentKravInnsendtMelding(
     val erFerdigBesvart = erDokumentasjonskravFerdigBesvart()
 
     private fun erDokumentasjonskravFerdigBesvart(): Boolean {
+        // TODO: Returverdien av all {} brukes ikke — funksjonen returnerer alltid true.
+        //  For at logikken skal fungere må dette fikses. I tillegg er filer alltid en tom liste
+        //  fordi elementene i JSON-arrayen er objekter, ikke tekststrenger — urn må trolig
+        //  ekstraheres eksplisitt fra hvert filobjekt for at isNotEmpty()-sjekken skal gi mening.
         alleDokumentasjonskrav.all {
             when (it.valg) {
                 "SEND_NÅ", "ETTERSENDT" -> it.filer.isNotEmpty() && it.bundle != null
@@ -87,8 +91,11 @@ class DokumentKravInnsendtMelding(
                                 skjemakode = it.get("skjemakode").asText(),
                                 valg = mapSvaret(it.get("svar").asText()),
                                 begrunnelse = it.get("begrunnelse")?.asText(),
-                                filer = it.get("filer")?.map { fil -> fil.asText() }?.toList() ?: emptyList(),
-                                bundle = it.get("bundle")?.asText(),
+                                filer =
+                                    it.get("filer")?.values()?.mapNotNull { fil ->
+                                        if (fil.isTextual) fil.textValue() else null
+                                    } ?: emptyList(),
+                                bundle = it.get("bundle")?.toString(),
                             )
                         }
                     }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/melding/DokumentKravInnsendtMelding.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/melding/DokumentKravInnsendtMelding.kt
@@ -87,10 +87,10 @@ class DokumentKravInnsendtMelding(
                         val dokumentkravForSeksjon = objectMapper.readTree(dokument).toList()
                         dokumentkravForSeksjon.map {
                             Dokumentasjonskrav(
-                                dokumentnavn = it.get("type").asText(),
-                                skjemakode = it.get("skjemakode").asText(),
-                                valg = mapSvaret(it.get("svar").asText()),
-                                begrunnelse = it.get("begrunnelse")?.asText(),
+                                dokumentnavn = it.get("type").asString(),
+                                skjemakode = it.get("skjemakode").asString(),
+                                valg = mapSvaret(it.get("svar").asString()),
+                                begrunnelse = it.get("begrunnelse")?.asString(),
                                 filer =
                                     it.get("filer")?.values()?.mapNotNull { fil ->
                                         if (fil.isTextual) fil.textValue() else null

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/melding/MeldingOmSøknadKlarTilJournalføringMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/melding/MeldingOmSøknadKlarTilJournalføringMottak.kt
@@ -50,14 +50,14 @@ class MeldingOmSøknadKlarTilJournalføringMottak(
         meterRegistry: MeterRegistry,
     ) {
         withMDC(
-            mapOf("søknadId" to packet["søknadId"].asText()),
+            mapOf("søknadId" to packet["søknadId"].asString()),
         ) {
             logg.info { "Mottok $EVENT_NAME hendelse for søknad ${packet["søknadId"]}" }
             sikkerLogg.info { "Mottok $EVENT_NAME hendelse for søknad ${packet["søknadId"]} og ident ${packet["ident"]}" }
 
             try {
                 val jsonNode = objectMapper.readTree(packet.toJson())
-                val ident = jsonNode.get("ident").asText()
+                val ident = jsonNode.get("ident").asString()
                 val søknadId = jsonNode.get("søknadId").asUUID()
                 val innsendtTidspunkt = jsonNode.get("innsendtTidspunkt").asLocalDateTime()
                 val søknadIderForMislykkedeSøknader: List<UUID> =

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/melding/SøknadEndretTilstandMelding.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/melding/SøknadEndretTilstandMelding.kt
@@ -1,11 +1,11 @@
 package no.nav.dagpenger.soknad.orkestrator.søknad.melding
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
 import io.ktor.util.toLowerCasePreservingASCIIRules
 import no.nav.dagpenger.soknad.orkestrator.config.objectMapper
 import no.nav.dagpenger.soknad.orkestrator.søknad.Søknad
 import no.nav.dagpenger.soknad.orkestrator.søknad.seksjon.SeksjonMedTidstempler
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 class SøknadEndretTilstandMelding(
@@ -133,7 +133,7 @@ class SøknadEndretTilstandMelding(
             }
 
             seksjonssvarJson.isArray -> {
-                seksjonssvarJson.map { element -> filtrerUgyldigeSpørsmålBasertPåType(element, tillatteFelter) }
+                seksjonssvarJson.values().map { element -> filtrerUgyldigeSpørsmålBasertPåType(element, tillatteFelter) }
             }
 
             seksjonssvarJson.isNull -> {
@@ -173,7 +173,7 @@ class SøknadEndretTilstandMelding(
                     }
 
                     node.isArray -> {
-                        node.forEach { traverse(it) }
+                        node.values().forEach { traverse(it) }
                     }
 
                     node.isObject -> {

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/melding/SøknadEndretTilstandMelding.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/melding/SøknadEndretTilstandMelding.kt
@@ -91,7 +91,7 @@ class SøknadEndretTilstandMelding(
             )
         val seksjon =
             mapOf(
-                "seksjonId" to seksjonsdataJson["seksjonId"].asText(),
+                "seksjonId" to seksjonsdataJson["seksjonId"].asString(),
                 "seksjonsvar" to filtrertSeksjonsdata,
                 "versjon" to seksjonsdataJson["versjon"].asInt(),
             )
@@ -141,7 +141,7 @@ class SøknadEndretTilstandMelding(
             }
 
             else -> {
-                seksjonssvarJson.asText()
+                seksjonssvarJson.asString()
             }
         }
 
@@ -165,9 +165,9 @@ class SøknadEndretTilstandMelding(
             fun traverse(node: JsonNode) {
                 when {
                     node.isObject && node.has("id") && node.has("type") -> {
-                        if (node["type"].asText() in gyldigeTyper && node["id"].asText() != "fødselsdato") {
+                        if (node["type"].asString() in gyldigeTyper && node["id"].asString() != "fødselsdato") {
                             seksjonMappet.add(
-                                node["id"].asText(),
+                                node["id"].asString(),
                             )
                         }
                     }
@@ -184,7 +184,7 @@ class SøknadEndretTilstandMelding(
 
             traverse(seksjon)
             SeksjonMedGyldigeFeltIder(
-                seksjonId = hentSeksjonIdFraNavn(seksjon["navn"].asText()),
+                seksjonId = hentSeksjonIdFraNavn(seksjon["navn"].asString()),
                 spørsmål = seksjonMappet,
             )
         }
@@ -202,7 +202,7 @@ class SøknadEndretTilstandMelding(
     private fun hentFeltFraSeksjon(
         jsonNode: JsonNode,
         nøkkel: String,
-    ): String = jsonNode["seksjonsvar"][nøkkel]?.asText() ?: ""
+    ): String = jsonNode["seksjonsvar"][nøkkel]?.asString() ?: ""
 
     data class SeksjonMedGyldigeFeltIder(
         val seksjonId: String,

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/MeldingOmEttersendingMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/MeldingOmEttersendingMottak.kt
@@ -56,11 +56,11 @@ internal class MeldingOmEttersendingMottak(
         meterRegistry: MeterRegistry,
     ) {
         val søknadId = packet["søknadId"].asUUID()
-        val ident = packet["ident"].asText()
+        val ident = packet["ident"].asString()
         val dokumentasjonskravJson =
-            packet["@løsning"][BEHOV]["dokumentasjonskravJson"].asText()
-        val seksjonId = packet["@løsning"][BEHOV]["seksjonId"].asText()
-        val journalpostId = packet["@løsning"][BEHOV]["journalpostId"].asText()
+            packet["@løsning"][BEHOV]["dokumentasjonskravJson"].asString()
+        val seksjonId = packet["@løsning"][BEHOV]["seksjonId"].asString()
+        val journalpostId = packet["@løsning"][BEHOV]["journalpostId"].asString()
 
         withLoggingContext(
             "søknadId" to søknadId.toString(),

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/SøknadMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/SøknadMottak.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.soknad.orkestrator.søknad.mottak
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
 import com.github.navikt.tbd_libs.rapids_and_rivers.River
 import com.github.navikt.tbd_libs.rapids_and_rivers.withMDC
@@ -15,6 +14,7 @@ import no.nav.dagpenger.soknad.orkestrator.søknad.SøknadMapper
 import no.nav.dagpenger.soknad.orkestrator.søknad.SøknadService
 import no.nav.dagpenger.soknad.orkestrator.søknad.db.SøknadRepository
 import no.nav.dagpenger.soknad.orkestrator.utils.asUUID
+import tools.jackson.databind.JsonNode
 
 class SøknadMottak(
     rapidsConnection: RapidsConnection,

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/SøknadMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/SøknadMottak.kt
@@ -41,9 +41,9 @@ class SøknadMottak(
         meterRegistry: MeterRegistry,
     ) {
         withMDC(
-            mapOf("søknadId" to packet["søknadId"].asText()),
+            mapOf("søknadId" to packet["søknadId"].asString()),
         ) {
-            val søknadId = packet["søknadId"].asText()
+            val søknadId = packet["søknadId"].asString()
             if (søknadId == "85882e9f-0bf7-478b-9d94-55cfb3fa8a53" || søknadId == "eb081524-2e25-42e2-963f-aac8f90c5b14") {
                 logger.warn {
                     "Mottok søknad_innsendt_varsel med $søknadId som vi hopper over fordi den kommer med ugyldig data som ikke kan mappes riktig og vil feile"
@@ -77,14 +77,14 @@ class SøknadMottak(
     private fun JsonNode.tilSøknad() = SøknadMapper(this).søknad
 
     private fun JsonNode.publiserMeldingOmSøknadInnsendt() {
-        val ident = this.get("ident").asText()
+        val ident = this.get("ident").asString()
         val søknadId = this.get("søknadId").asUUID()
 
         søknadService.publiserMeldingOmSøknadInnsendt(søknadId, ident)
     }
 
     private fun opprettOgLagreKomplettSøknaddata(søknadMelding: JsonNode): JsonNode {
-        val ident = søknadMelding.get("ident").asText()
+        val ident = søknadMelding.get("ident").asString()
         val søknadId = søknadMelding.get("søknadId").asUUID()
         val seksjoner = søknadMelding["søknadData"]["seksjoner"]
 

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/SøknadPdfGenerertOgMellomlagretMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/SøknadPdfGenerertOgMellomlagretMottak.kt
@@ -51,7 +51,7 @@ internal class SøknadPdfGenerertOgMellomlagretMottak(
     ) {
         val søknadId = packet["søknadId"].asUUID()
         if (søknadId.toString() == "ad6e29ea-7eaa-42ae-9e4c-dcb3e8f2e7ae") return
-        val ident = packet["ident"].asText()
+        val ident = packet["ident"].asString()
         withLoggingContext(
             "søknadId" to søknadId.toString(),
         ) {

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/SøknadPdfOgVedleggJournalførtMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/SøknadPdfOgVedleggJournalførtMottak.kt
@@ -52,8 +52,8 @@ internal class SøknadPdfOgVedleggJournalførtMottak(
         meterRegistry: MeterRegistry,
     ) {
         val søknadId = packet["søknadId"].asUUID()
-        val ident = packet["ident"].asText()
-        val journalpostId = packet["@løsning"][BEHOV]["journalpostId"].asText()
+        val ident = packet["ident"].asString()
+        val journalpostId = packet["@løsning"][BEHOV]["journalpostId"].asString()
         val journalførtTidspunkt = packet["@løsning"][BEHOV]["journalførtTidspunkt"].asLocalDateTime()
 
         withLoggingContext(

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/SøknadSlettetMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/SøknadSlettetMottak.kt
@@ -35,13 +35,13 @@ class SøknadSlettetMottak(
         meterRegistry: MeterRegistry,
     ) {
         withMDC(
-            mapOf("søknadId" to packet["søknad_uuid"].asText()),
+            mapOf("søknadId" to packet["søknad_uuid"].asString()),
         ) {
             logger.info { "Mottok søknad slettet hendelse for søknad ${packet["søknad_uuid"]}" }
             sikkerlogg.info { "Mottok søknad slettet hendelse: ${packet.toJson()}" }
 
             val søknadId = packet["søknad_uuid"].asUUID()
-            val ident = packet["ident"].asText()
+            val ident = packet["ident"].asString()
 
             søknadService.slettSøknadOgInkrementerMetrikk(søknadId, ident, "quiz")
         }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/pdf/PdfPayloadService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/pdf/PdfPayloadService.kt
@@ -138,7 +138,7 @@ class PdfPayloadService(
                 while (felter.hasNext()) {
                     val (feltNavn, feltVerdi) = felter.next()
                     if (feltNavn in felterMedMarkup && feltVerdi.isTextual) {
-                        node.put(feltNavn, normaliserRichText(feltVerdi.asText()))
+                        node.put(feltNavn, normaliserRichText(feltVerdi.asString()))
                     } else {
                         normaliserHtmlFelter(feltVerdi)
                     }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/pdf/PdfPayloadService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/pdf/PdfPayloadService.kt
@@ -1,8 +1,5 @@
 package no.nav.dagpenger.soknad.orkestrator.søknad.pdf
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.ArrayNode
-import com.fasterxml.jackson.databind.node.ObjectNode
 import freemarker.template.Configuration
 import freemarker.template.Configuration.VERSION_2_3_34
 import no.nav.dagpenger.soknad.orkestrator.config.objectMapper
@@ -10,6 +7,9 @@ import no.nav.dagpenger.soknad.orkestrator.søknad.SøknadPersonalia
 import no.nav.dagpenger.soknad.orkestrator.søknad.db.SøknadPersonaliaRepository
 import no.nav.dagpenger.soknad.orkestrator.søknad.db.SøknadRepository
 import no.nav.dagpenger.soknad.orkestrator.søknad.seksjon.SeksjonRepository
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.ArrayNode
+import tools.jackson.databind.node.ObjectNode
 import java.io.ByteArrayOutputStream
 import java.io.OutputStreamWriter
 import java.time.format.DateTimeFormatter

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/seksjon/SeksjonService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/seksjon/SeksjonService.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.soknad.orkestrator.søknad.seksjon
 
-import com.fasterxml.jackson.databind.json.JsonMapper
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.dagpenger.soknad.orkestrator.søknad.Dokument
@@ -10,6 +9,7 @@ import no.nav.dagpenger.soknad.orkestrator.søknad.Tilstand
 import no.nav.dagpenger.soknad.orkestrator.søknad.db.SøknadRepository
 import no.nav.dagpenger.soknad.orkestrator.søknad.melding.MeldingOmEttersending
 import no.nav.dagpenger.soknad.orkestrator.søknad.melding.SeksjonDataTilStatistikk
+import tools.jackson.databind.json.JsonMapper
 import java.time.LocalDateTime
 import java.util.UUID
 

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/AsUUID.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/AsUUID.kt
@@ -3,4 +3,4 @@ package no.nav.dagpenger.soknad.orkestrator.utils
 import tools.jackson.databind.JsonNode
 import java.util.UUID
 
-internal fun JsonNode.asUUID(): UUID = this.asText().let { UUID.fromString(it) }
+internal fun JsonNode.asUUID(): UUID = this.asString().let { UUID.fromString(it) }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/AsUUID.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/AsUUID.kt
@@ -1,6 +1,6 @@
 package no.nav.dagpenger.soknad.orkestrator.utils
 
-import com.fasterxml.jackson.databind.JsonNode
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 internal fun JsonNode.asUUID(): UUID = this.asText().let { UUID.fromString(it) }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/HttpKlient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/HttpKlient.kt
@@ -6,7 +6,7 @@ import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
-import io.ktor.serialization.jackson.jackson
+import io.ktor.serialization.jackson3.jackson
 import no.nav.dagpenger.soknad.orkestrator.config.configure
 
 fun configureHttpClient(httpClientEngine: HttpClientEngine = CIO.create()) =

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/JsonNode.erBoolean.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/JsonNode.erBoolean.kt
@@ -12,7 +12,13 @@ fun JsonNode.erBoolean(): Boolean =
             false
         }
 
+        this.isBoolean -> {
+            this.booleanValue()
+        }
+
         else -> {
-            this.asBoolean()
+            // Jackson 3 kaster for strenger som ikke er "true"/"false".
+            // Matcher Jackson 2-atferd: kun eksakt "true" gir true.
+            this.asText().lowercase() == "true"
         }
     }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/JsonNode.erBoolean.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/JsonNode.erBoolean.kt
@@ -4,11 +4,11 @@ import tools.jackson.databind.JsonNode
 
 fun JsonNode.erBoolean(): Boolean =
     when {
-        this.asText().lowercase() == "ja" -> {
+        this.asString().lowercase() == "ja" -> {
             true
         }
 
-        this.asText().lowercase() == "nei" -> {
+        this.asString().lowercase() == "nei" -> {
             false
         }
 
@@ -19,6 +19,6 @@ fun JsonNode.erBoolean(): Boolean =
         else -> {
             // Jackson 3 kaster for strenger som ikke er "true"/"false".
             // Matcher Jackson 2-atferd: kun eksakt "true" gir true.
-            this.asText().lowercase() == "true"
+            this.asString().lowercase() == "true"
         }
     }

--- a/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/JsonNode.erBoolean.kt
+++ b/src/main/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/JsonNode.erBoolean.kt
@@ -1,6 +1,6 @@
 package no.nav.dagpenger.soknad.orkestrator.utils
 
-import com.fasterxml.jackson.databind.JsonNode
+import tools.jackson.databind.JsonNode
 
 fun JsonNode.erBoolean(): Boolean =
     when {

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BarnetilleggBehovLøserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BarnetilleggBehovLøserTest.kt
@@ -121,30 +121,30 @@ class BarnetilleggBehovLøserTest {
         løsteBarn.size() shouldBe 3
         løsteBarn[0].also {
             it["søknadbarnId"].asUUID() shouldBe lagretSøknadbarnId
-            it["fornavnOgMellomnavn"].asText() shouldBe "Ola"
-            it["etternavn"].asText() shouldBe "Nordmann"
-            it["fødselsdato"].asText() shouldBe "2000-01-01"
-            it["statsborgerskap"].asText() shouldBe "NOR"
+            it["fornavnOgMellomnavn"].asString() shouldBe "Ola"
+            it["etternavn"].asString() shouldBe "Nordmann"
+            it["fødselsdato"].asString() shouldBe "2000-01-01"
+            it["statsborgerskap"].asString() shouldBe "NOR"
             it["kvalifiserer"].asBoolean() shouldBe true
             it["barnetilleggFom"].asLocalDate() shouldBe 1.januar(2000)
             it["barnetilleggTom"].asLocalDate() shouldBe 1.januar(2018)
-            it["endretAv"].asText() shouldBe "123"
-            it["begrunnelse"].asText() shouldBe "Begrunnelse for endring"
+            it["endretAv"].asString() shouldBe "123"
+            it["begrunnelse"].asString() shouldBe "Begrunnelse for endring"
         }
         løsteBarn[1].also {
             it["søknadbarnId"].asUUID() shouldBe lagretSøknadbarnId
-            it["fornavnOgMellomnavn"].asText() shouldBe "Per"
-            it["etternavn"].asText() shouldBe "Nordmann"
-            it["fødselsdato"].asText() shouldBe "2000-01-01"
-            it["statsborgerskap"].asText() shouldBe "NOR"
+            it["fornavnOgMellomnavn"].asString() shouldBe "Per"
+            it["etternavn"].asString() shouldBe "Nordmann"
+            it["fødselsdato"].asString() shouldBe "2000-01-01"
+            it["statsborgerskap"].asString() shouldBe "NOR"
             it["kvalifiserer"].asBoolean() shouldBe false
         }
         løsteBarn[2].also {
             it["søknadbarnId"].asUUID() shouldBe lagretSøknadbarnId
-            it["fornavnOgMellomnavn"].asText() shouldBe "Per"
-            it["etternavn"].asText() shouldBe "Utland"
-            it["fødselsdato"].asText() shouldBe "2000-01-01"
-            it["statsborgerskap"].asText() shouldBe "UTL"
+            it["fornavnOgMellomnavn"].asString() shouldBe "Per"
+            it["etternavn"].asString() shouldBe "Utland"
+            it["fødselsdato"].asString() shouldBe "2000-01-01"
+            it["statsborgerskap"].asString() shouldBe "UTL"
             it["kvalifiserer"].asBoolean() shouldBe true
         }
     }
@@ -171,10 +171,10 @@ class BarnetilleggBehovLøserTest {
         løsteBarn.size() shouldBe 3
         løsteBarn[0].also {
             it["søknadbarnId"].asUUID().shouldNotBeNull()
-            it["fornavnOgMellomnavn"].asText() shouldBe "SMISKENDE"
-            it["etternavn"].asText() shouldBe "KJENNING"
-            it["fødselsdato"].asText() shouldBe "2013-05-26"
-            it["statsborgerskap"].asText() shouldBe "NOR"
+            it["fornavnOgMellomnavn"].asString() shouldBe "SMISKENDE"
+            it["etternavn"].asString() shouldBe "KJENNING"
+            it["fødselsdato"].asString() shouldBe "2013-05-26"
+            it["statsborgerskap"].asString() shouldBe "NOR"
             it["kvalifiserer"].asBoolean() shouldBe false
             it["barnetilleggFom"].isNull shouldBe true
             it["barnetilleggTom"].isNull shouldBe true
@@ -183,8 +183,8 @@ class BarnetilleggBehovLøserTest {
         }
         løsteBarn[1].also {
             it["kvalifiserer"].asBoolean() shouldBe true
-            it["barnetilleggFom"].asText() shouldBe "2009-11-12"
-            it["barnetilleggTom"].asText() shouldBe "2027-11-12"
+            it["barnetilleggFom"].asString() shouldBe "2009-11-12"
+            it["barnetilleggTom"].asString() shouldBe "2027-11-12"
         }
         løsteBarn[2].also {
             it["kvalifiserer"].asBoolean() shouldBe false

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BarnetilleggBehovLøserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BarnetilleggBehovLøserTest.kt
@@ -176,10 +176,10 @@ class BarnetilleggBehovLøserTest {
             it["fødselsdato"].asText() shouldBe "2013-05-26"
             it["statsborgerskap"].asText() shouldBe "NOR"
             it["kvalifiserer"].asBoolean() shouldBe false
-            it["barnetilleggFom"].asText().shouldBe("null")
-            it["barnetilleggTom"].asText().shouldBe("null")
-            it["endretAv"].asText().shouldBe("null")
-            it["begrunnelse"].asText().shouldBe("null")
+            it["barnetilleggFom"].isNull shouldBe true
+            it["barnetilleggTom"].isNull shouldBe true
+            it["endretAv"].isNull shouldBe true
+            it["begrunnelse"].isNull shouldBe true
         }
         løsteBarn[1].also {
             it["kvalifiserer"].asBoolean() shouldBe true
@@ -188,8 +188,8 @@ class BarnetilleggBehovLøserTest {
         }
         løsteBarn[2].also {
             it["kvalifiserer"].asBoolean() shouldBe false
-            it["barnetilleggFom"].asText() shouldBe "null"
-            it["barnetilleggTom"].asText() shouldBe "null"
+            it["barnetilleggFom"].isNull shouldBe true
+            it["barnetilleggTom"].isNull shouldBe true
         }
     }
 

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BarnetilleggV2BehovLøserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BarnetilleggV2BehovLøserTest.kt
@@ -123,28 +123,28 @@ class BarnetilleggV2BehovLøserTest {
         barnetilleggV2Løsning["søknadbarnId"].asUUID() shouldBe lagretSøknadbarnId
         løsteBarn.size() shouldBe 3
         løsteBarn[0].also {
-            it["fornavnOgMellomnavn"].asText() shouldBe "Ola"
-            it["etternavn"].asText() shouldBe "Nordmann"
-            it["fødselsdato"].asText() shouldBe "2000-01-01"
-            it["statsborgerskap"].asText() shouldBe "NOR"
+            it["fornavnOgMellomnavn"].asString() shouldBe "Ola"
+            it["etternavn"].asString() shouldBe "Nordmann"
+            it["fødselsdato"].asString() shouldBe "2000-01-01"
+            it["statsborgerskap"].asString() shouldBe "NOR"
             it["kvalifiserer"].asBoolean() shouldBe true
             it["barnetilleggFom"].asLocalDate() shouldBe 1.januar(2000)
             it["barnetilleggTom"].asLocalDate() shouldBe 1.januar(2018)
-            it["endretAv"].asText() shouldBe "123"
-            it["begrunnelse"].asText() shouldBe "Begrunnelse for endring"
+            it["endretAv"].asString() shouldBe "123"
+            it["begrunnelse"].asString() shouldBe "Begrunnelse for endring"
         }
         løsteBarn[1].also {
-            it["fornavnOgMellomnavn"].asText() shouldBe "Per"
-            it["etternavn"].asText() shouldBe "Nordmann"
-            it["fødselsdato"].asText() shouldBe "2000-01-01"
-            it["statsborgerskap"].asText() shouldBe "NOR"
+            it["fornavnOgMellomnavn"].asString() shouldBe "Per"
+            it["etternavn"].asString() shouldBe "Nordmann"
+            it["fødselsdato"].asString() shouldBe "2000-01-01"
+            it["statsborgerskap"].asString() shouldBe "NOR"
             it["kvalifiserer"].asBoolean() shouldBe false
         }
         løsteBarn[2].also {
-            it["fornavnOgMellomnavn"].asText() shouldBe "Per"
-            it["etternavn"].asText() shouldBe "Utland"
-            it["fødselsdato"].asText() shouldBe "2000-01-01"
-            it["statsborgerskap"].asText() shouldBe "UTL"
+            it["fornavnOgMellomnavn"].asString() shouldBe "Per"
+            it["etternavn"].asString() shouldBe "Utland"
+            it["fødselsdato"].asString() shouldBe "2000-01-01"
+            it["statsborgerskap"].asString() shouldBe "UTL"
             it["kvalifiserer"].asBoolean() shouldBe true
         }
     }
@@ -196,10 +196,10 @@ class BarnetilleggV2BehovLøserTest {
         barnetilleggV2Løsning["søknadbarnId"] shouldNotBe null
         løsteBarn.size() shouldBe 3
         løsteBarn[0].also {
-            it["fornavnOgMellomnavn"].asText() shouldBe "SMISKENDE"
-            it["etternavn"].asText() shouldBe "KJENNING"
-            it["fødselsdato"].asText() shouldBe "2013-05-26"
-            it["statsborgerskap"].asText() shouldBe "NOR"
+            it["fornavnOgMellomnavn"].asString() shouldBe "SMISKENDE"
+            it["etternavn"].asString() shouldBe "KJENNING"
+            it["fødselsdato"].asString() shouldBe "2013-05-26"
+            it["statsborgerskap"].asString() shouldBe "NOR"
             it["kvalifiserer"].asBoolean() shouldBe false
             it["barnetilleggFom"].isNull shouldBe true
             it["barnetilleggTom"].isNull shouldBe true
@@ -208,8 +208,8 @@ class BarnetilleggV2BehovLøserTest {
         }
         løsteBarn[1].also {
             it["kvalifiserer"].asBoolean() shouldBe true
-            it["barnetilleggFom"].asText() shouldBe "2009-11-12"
-            it["barnetilleggTom"].asText() shouldBe "2027-11-12"
+            it["barnetilleggFom"].asString() shouldBe "2009-11-12"
+            it["barnetilleggTom"].asString() shouldBe "2027-11-12"
         }
         løsteBarn[2].also {
             it["kvalifiserer"].asBoolean() shouldBe false
@@ -267,10 +267,10 @@ class BarnetilleggV2BehovLøserTest {
         val barnetilleggV2Løsning = testRapid.inspektør.field(0, "@løsning")[BarnetilleggV2.name]["verdi"]
         val løsteBarn = barnetilleggV2Løsning["barn"]
         løsteBarn.size() shouldBe 1
-        løsteBarn[0]["fornavnOgMellomnavn"].asText() shouldBe "Saksbehandler-redigert"
+        løsteBarn[0]["fornavnOgMellomnavn"].asString() shouldBe "Saksbehandler-redigert"
         løsteBarn[0]["kvalifiserer"].asBoolean() shouldBe true
-        løsteBarn[0]["endretAv"].asText() shouldBe "Z991234"
-        løsteBarn[0]["begrunnelse"].asText() shouldBe "Endret av saksbehandler"
+        løsteBarn[0]["endretAv"].asString() shouldBe "Z991234"
+        løsteBarn[0]["begrunnelse"].asString() shouldBe "Endret av saksbehandler"
     }
 
     @Language("JSON")

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BarnetilleggV2BehovLøserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/BarnetilleggV2BehovLøserTest.kt
@@ -201,10 +201,10 @@ class BarnetilleggV2BehovLøserTest {
             it["fødselsdato"].asText() shouldBe "2013-05-26"
             it["statsborgerskap"].asText() shouldBe "NOR"
             it["kvalifiserer"].asBoolean() shouldBe false
-            it["barnetilleggFom"].asText().shouldBe("null")
-            it["barnetilleggTom"].asText().shouldBe("null")
-            it["endretAv"].asText().shouldBe("null")
-            it["begrunnelse"].asText().shouldBe("null")
+            it["barnetilleggFom"].isNull shouldBe true
+            it["barnetilleggTom"].isNull shouldBe true
+            it["endretAv"].isNull shouldBe true
+            it["begrunnelse"].isNull shouldBe true
         }
         løsteBarn[1].also {
             it["kvalifiserer"].asBoolean() shouldBe true
@@ -213,8 +213,8 @@ class BarnetilleggV2BehovLøserTest {
         }
         løsteBarn[2].also {
             it["kvalifiserer"].asBoolean() shouldBe false
-            it["barnetilleggFom"].asText() shouldBe "null"
-            it["barnetilleggTom"].asText() shouldBe "null"
+            it["barnetilleggFom"].isNull shouldBe true
+            it["barnetilleggTom"].isNull shouldBe true
         }
     }
 

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/PermittertGrensearbeiderBehovløserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/PermittertGrensearbeiderBehovløserTest.kt
@@ -90,16 +90,16 @@ class PermittertGrensearbeiderBehovløserTest {
                     any(),
                 )
             } returns
-                """
-                {
-                  "seksjonId":"personalia",
-                  "seksjonsvar": {
-                    "reisteDuHjemTilLandetDuBorI": "${testData.first}",
-                    "reisteDuITaktMedRotasjon": "${testData.second}"
-                  },
-                  "versjon": 1
+                buildString {
+                    append("""{"seksjonId":"personalia","seksjonsvar":{""")
+                    val felter =
+                        listOfNotNull(
+                            testData.first?.let { """"reisteDuHjemTilLandetDuBorI":"$it"""" },
+                            testData.second?.let { """"reisteDuITaktMedRotasjon":"$it"""" },
+                        )
+                    append(felter.joinToString(","))
+                    append("""},"versjon":1}""")
                 }
-                """.trimIndent()
         }
 
         // Må også lagre søknadstidspunkt fordi det er denne som brukes for å sette gjelderFra i første omgang

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløserTest.kt
@@ -537,12 +537,12 @@ class SøknadsdataBehovløserTest {
             val verdi = løsning["verdi"]
             val avsluttetArbeidsforhold = verdi["avsluttetArbeidsforhold"]
             avsluttetArbeidsforhold.size() shouldBe 2
-            avsluttetArbeidsforhold[0]["sluttårsak"].asText() shouldBe "SAGT_OPP_AV_ARBEIDSGIVER"
+            avsluttetArbeidsforhold[0]["sluttårsak"].asString() shouldBe "SAGT_OPP_AV_ARBEIDSGIVER"
             avsluttetArbeidsforhold[0]["fiskeforedling"].asBoolean() shouldBe false
-            avsluttetArbeidsforhold[0]["land"].asText() shouldBe "NOR"
-            avsluttetArbeidsforhold[1]["sluttårsak"].asText() shouldBe "PERMITTERT"
+            avsluttetArbeidsforhold[0]["land"].asString() shouldBe "NOR"
+            avsluttetArbeidsforhold[1]["sluttårsak"].asString() shouldBe "PERMITTERT"
             avsluttetArbeidsforhold[1]["fiskeforedling"].asBoolean() shouldBe true
-            avsluttetArbeidsforhold[1]["land"].asText() shouldBe "SWE"
+            avsluttetArbeidsforhold[1]["land"].asString() shouldBe "SWE"
             verdi["søknad_uuid"].asUUID() shouldBe søknadId
             verdi["ønskerDagpengerFraDato"].asLocalDate() shouldBe now
         }
@@ -574,12 +574,12 @@ class SøknadsdataBehovløserTest {
             val verdi = løsning["verdi"]
             val avsluttetArbeidsforhold = verdi["avsluttetArbeidsforhold"]
             avsluttetArbeidsforhold.size() shouldBe 2
-            avsluttetArbeidsforhold[0]["sluttårsak"].asText() shouldBe "SAGT_OPP_AV_ARBEIDSGIVER"
+            avsluttetArbeidsforhold[0]["sluttårsak"].asString() shouldBe "SAGT_OPP_AV_ARBEIDSGIVER"
             avsluttetArbeidsforhold[0]["fiskeforedling"].asBoolean() shouldBe false
-            avsluttetArbeidsforhold[0]["land"].asText() shouldBe "NOR"
-            avsluttetArbeidsforhold[1]["sluttårsak"].asText() shouldBe "PERMITTERT"
+            avsluttetArbeidsforhold[0]["land"].asString() shouldBe "NOR"
+            avsluttetArbeidsforhold[1]["sluttårsak"].asString() shouldBe "PERMITTERT"
             avsluttetArbeidsforhold[1]["fiskeforedling"].asBoolean() shouldBe true
-            avsluttetArbeidsforhold[1]["land"].asText() shouldBe "SWE"
+            avsluttetArbeidsforhold[1]["land"].asString() shouldBe "SWE"
             verdi["søknad_uuid"].asUUID() shouldBe søknadId
             verdi["ønskerDagpengerFraDato"].asLocalDate() shouldBe now
         }
@@ -625,12 +625,12 @@ class SøknadsdataBehovløserTest {
             val verdi = løsning["verdi"]
             val avsluttetArbeidsforhold = verdi["avsluttetArbeidsforhold"]
             avsluttetArbeidsforhold.size() shouldBe 2
-            avsluttetArbeidsforhold[0]["sluttårsak"].asText() shouldBe "SAGT_OPP_AV_ARBEIDSGIVER"
+            avsluttetArbeidsforhold[0]["sluttårsak"].asString() shouldBe "SAGT_OPP_AV_ARBEIDSGIVER"
             avsluttetArbeidsforhold[0]["fiskeforedling"].asBoolean() shouldBe false
-            avsluttetArbeidsforhold[0]["land"].asText() shouldBe "NOR"
-            avsluttetArbeidsforhold[1]["sluttårsak"].asText() shouldBe "PERMITTERT"
+            avsluttetArbeidsforhold[0]["land"].asString() shouldBe "NOR"
+            avsluttetArbeidsforhold[1]["sluttårsak"].asString() shouldBe "PERMITTERT"
             avsluttetArbeidsforhold[1]["fiskeforedling"].asBoolean() shouldBe true
-            avsluttetArbeidsforhold[1]["land"].asText() shouldBe "SWE"
+            avsluttetArbeidsforhold[1]["land"].asString() shouldBe "SWE"
             verdi["søknad_uuid"].asUUID() shouldBe søknadId
             verdi["ønskerDagpengerFraDato"].asLocalDate() shouldBe now
         }

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/behov/løsere/SøknadsdataBehovløserTest.kt
@@ -87,6 +87,52 @@ class SøknadsdataBehovløserTest {
         } returns dinSituasjonMedGjenopptakelseOrkestratorJson(now)
 
         every {
+            seksjonRepository.hentSeksjonsvar(
+                any(),
+                ident,
+                "personalia",
+            )
+        } returns personaliaOrkestratorJson("ja", "NOR")
+
+        every {
+            seksjonRepository.hentSeksjonsvarEllerKastException(
+                ident,
+                any(),
+                "annen-pengestotte",
+            )
+        } returns annenPengestøtteOrkestratorJson("nei", "nei")
+
+        every {
+            seksjonRepository.hentSeksjonsvarEllerKastException(
+                ident,
+                any(),
+                "barnetillegg",
+            )
+        } returns barnetilleggUtenBarn()
+
+        every {
+            seksjonRepository.hentSeksjonsvarEllerKastException(
+                ident,
+                any(),
+                "arbeidsforhold",
+            )
+        } returns arbeidsforholdUtenRegistrerteAvsluttedeArbeidsforholdOrkestratorJson()
+
+        every {
+            seksjonRepository.hentSeksjonsvarEllerKastException(
+                ident,
+                any(),
+                "reell-arbeidssoker",
+            )
+        } returns
+            reellArbeidssøkerOrkestratorJson(
+                kanDuTaAlleTyperArbeid = "nei",
+                kanDuJobbeIHeleNorge = "nei",
+                kanDuJobbeBådeHeltidOgDeltid = "nei",
+                erDuVilligTilÅBytteYrkeEllerGåNedILønn = "nei",
+            )
+
+        every {
             seksjonRepository.hentSeksjonsvarEllerKastException(
                 any(),
                 any(),

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/LandApiTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/LandApiTest.kt
@@ -1,26 +1,31 @@
 package no.nav.dagpenger.soknad.orkestrator.opplysning
 
-import com.fasterxml.jackson.module.kotlin.readValue
-import com.github.navikt.tbd_libs.naisful.test.naisfulTestApp
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
-import io.micrometer.prometheusmetrics.PrometheusConfig
-import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import io.ktor.serialization.jackson3.jackson
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.testing.testApplication
 import no.nav.dagpenger.soknad.orkestrator.api.models.LandDTO
+import no.nav.dagpenger.soknad.orkestrator.config.configure
 import no.nav.dagpenger.soknad.orkestrator.config.objectMapper
+import tools.jackson.module.kotlin.readValue
 import kotlin.test.Test
 
 class LandApiTest {
     @Test
     fun `Land svarer med 200 OK og en liste med Land`() {
-        naisfulTestApp(
-            testApplicationModule = { landApi() },
-            meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT),
-            objectMapper = objectMapper,
-        ) {
+        testApplication {
+            application {
+                install(ContentNegotiation) {
+                    jackson { configure() }
+                }
+                landApi()
+            }
+
             val respons = client.get("/land")
 
             respons.status shouldBe HttpStatusCode.OK

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/OpplysningApiTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/OpplysningApiTest.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.soknad.orkestrator.opplysning
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -34,6 +33,7 @@ import no.nav.dagpenger.soknad.orkestrator.utils.TestApplication.testAzureADToke
 import no.nav.dagpenger.soknad.orkestrator.utils.TestApplication.withMockAuthServerAndTestApplication
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import tools.jackson.module.kotlin.readValue
 import java.time.LocalDate
 import java.util.UUID
 import kotlin.test.Test

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/OpplysningServiceTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/opplysning/OpplysningServiceTest.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.soknad.orkestrator.opplysning
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -20,6 +19,7 @@ import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.BarnSvar
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.db.QuizOpplysningRepository
 import no.nav.dagpenger.soknad.orkestrator.søknad.Søknad
 import no.nav.dagpenger.soknad.orkestrator.søknad.db.SøknadRepository
+import tools.jackson.module.kotlin.readValue
 import java.time.LocalDate
 import java.util.UUID
 import kotlin.test.Test

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatype/ArbeidsforholdTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/quizOpplysning/datatype/ArbeidsforholdTest.kt
@@ -1,9 +1,9 @@
 package no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatype
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import io.kotest.matchers.shouldBe
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.Arbeidsforhold
 import no.nav.dagpenger.soknad.orkestrator.quizOpplysning.datatyper.Sluttårsak
+import tools.jackson.databind.json.JsonMapper
 import kotlin.test.Test
 
 class ArbeidsforholdTest {
@@ -22,7 +22,7 @@ class ArbeidsforholdTest {
 
 //language=JSON
 val arbeidsforholdPermittertFraFiskeri =
-    ObjectMapper().readTree(
+    JsonMapper().readTree(
         """
         [
           {
@@ -51,7 +51,7 @@ val arbeidsforholdPermittertFraFiskeri =
 
 //language=JSON
 val arbeidsforholdPermittert =
-    ObjectMapper().readTree(
+    JsonMapper().readTree(
         """
         [
           {
@@ -80,7 +80,7 @@ val arbeidsforholdPermittert =
 
 //language=JSON
 val arbeidsforholdAvskjediget =
-    ObjectMapper().readTree(
+    JsonMapper().readTree(
         """
         [
           {
@@ -104,7 +104,7 @@ val arbeidsforholdAvskjediget =
 
 //language=JSON
 val arbeidsforholdKontraktUtgått =
-    ObjectMapper().readTree(
+    JsonMapper().readTree(
         """
         [
           {
@@ -128,7 +128,7 @@ val arbeidsforholdKontraktUtgått =
 
 //language=JSON
 val arbeidsforholdRedusertArbeidstid =
-    ObjectMapper().readTree(
+    JsonMapper().readTree(
         """
         [
           {
@@ -152,7 +152,7 @@ val arbeidsforholdRedusertArbeidstid =
 
 //language=JSON
 val arbeidsforholdSagtOppAvArbeidsgiver =
-    ObjectMapper().readTree(
+    JsonMapper().readTree(
         """
         [
           {
@@ -181,7 +181,7 @@ val arbeidsforholdSagtOppAvArbeidsgiver =
 
 //language=JSON
 val arbeidsforholdSagtOppSelv =
-    ObjectMapper().readTree(
+    JsonMapper().readTree(
         """
         [
           {
@@ -210,7 +210,7 @@ val arbeidsforholdSagtOppSelv =
 
 //language=JSON
 val arbeidsforholdIkkeEndret =
-    ObjectMapper().readTree(
+    JsonMapper().readTree(
         """
         [
           {

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/MeldingOmSøknadKlarTilJournalføringMottakTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/MeldingOmSøknadKlarTilJournalføringMottakTest.kt
@@ -54,30 +54,30 @@ class MeldingOmSøknadKlarTilJournalføringMottakTest {
         verify { pdfPayloadService.genererBruttoPdfPayload(søknadId, ident) }
         verify { pdfPayloadService.genererNettoPdfPayload(søknadId, ident) }
         rapidsConnection.inspektør.size shouldBe 3
-        rapidsConnection.inspektør.message(0)["@behov"][0].asText() shouldBe "generer_og_mellomlagre_søknad_pdf"
-        rapidsConnection.inspektør.message(1)["@event_name"].asText() shouldBe "søknad_endret_tilstand"
+        rapidsConnection.inspektør.message(0)["@behov"][0].asString() shouldBe "generer_og_mellomlagre_søknad_pdf"
+        rapidsConnection.inspektør.message(1)["@event_name"].asString() shouldBe "søknad_endret_tilstand"
 
         val søknadsdata = rapidsConnection.inspektør.message(1)["søknadsdata"]
         søknadsdata shouldNotBe null
         søknadsdata["innsendt"] shouldNotBe null
         søknadsdata["verneplikt"] shouldNotBe null
-        søknadsdata["verneplikt"]["seksjonsdata"].asText() shouldBe seksjoner.find { it.seksjonId == "verneplikt" }?.data
+        søknadsdata["verneplikt"]["seksjonsdata"].asString() shouldBe seksjoner.find { it.seksjonId == "verneplikt" }?.data
         søknadsdata["din-situasjon"] shouldNotBe null
-        søknadsdata["din-situasjon"]["seksjonsdata"].asText().trim() shouldBe
+        søknadsdata["din-situasjon"]["seksjonsdata"].asString().trim() shouldBe
             """{"seksjonId":"din-situasjon","seksjonsvar":{"harDuMottattDagpengerFraNavILøpetAvDeSiste52Ukene":"ja","hvilkenDatoSøkerDuGjenopptakFra":"2024-02-21"},"versjon":1}"""
 
-        rapidsConnection.inspektør.message(2)["@event_name"].asText() shouldBe "dokumentkrav_innsendt"
-        rapidsConnection.inspektør.message(2)["innsendingsType"].asText() shouldBe "INNSENDT"
+        rapidsConnection.inspektør.message(2)["@event_name"].asString() shouldBe "dokumentkrav_innsendt"
+        rapidsConnection.inspektør.message(2)["innsendingsType"].asString() shouldBe "INNSENDT"
         rapidsConnection.inspektør.message(2)["ferdigBesvart"].asBoolean() shouldBe true
-        rapidsConnection.inspektør.message(2)["kilde"].asText() shouldBe "orkestrator"
+        rapidsConnection.inspektør.message(2)["kilde"].asString() shouldBe "orkestrator"
 
         val dokumenstasjonskrav = rapidsConnection.inspektør.message(2)["dokumentkrav"]
         dokumenstasjonskrav.size() shouldBe 5
-        dokumenstasjonskrav[0]["valg"].asText() shouldBe "SEND_SENERE"
-        dokumenstasjonskrav[1]["valg"].asText() shouldBe "SEND_TIDLIGERE"
-        dokumenstasjonskrav[2]["valg"].asText() shouldBe "SENDER_IKKE"
-        dokumenstasjonskrav[3]["valg"].asText() shouldBe "SEND_NÅ"
-        dokumenstasjonskrav[4]["valg"].asText() shouldBe "ETTERSENDT"
+        dokumenstasjonskrav[0]["valg"].asString() shouldBe "SEND_SENERE"
+        dokumenstasjonskrav[1]["valg"].asString() shouldBe "SEND_TIDLIGERE"
+        dokumenstasjonskrav[2]["valg"].asString() shouldBe "SENDER_IKKE"
+        dokumenstasjonskrav[3]["valg"].asString() shouldBe "SEND_NÅ"
+        dokumenstasjonskrav[4]["valg"].asString() shouldBe "ETTERSENDT"
     }
 
     @Test

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/MeldingOmSøknadKlarTilJournalføringMottakTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/MeldingOmSøknadKlarTilJournalføringMottakTest.kt
@@ -68,7 +68,7 @@ class MeldingOmSøknadKlarTilJournalføringMottakTest {
 
         rapidsConnection.inspektør.message(2)["@event_name"].asText() shouldBe "dokumentkrav_innsendt"
         rapidsConnection.inspektør.message(2)["innsendingsType"].asText() shouldBe "INNSENDT"
-        rapidsConnection.inspektør.message(2)["ferdigBesvart"].asText() shouldBe "true"
+        rapidsConnection.inspektør.message(2)["ferdigBesvart"].asBoolean() shouldBe true
         rapidsConnection.inspektør.message(2)["kilde"].asText() shouldBe "orkestrator"
 
         val dokumenstasjonskrav = rapidsConnection.inspektør.message(2)["dokumentkrav"]

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadMapperTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadMapperTest.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.soknad.orkestrator.søknad
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
@@ -19,6 +18,7 @@ import no.nav.dagpenger.soknad.orkestrator.utils.februar
 import no.nav.dagpenger.soknad.orkestrator.utils.januar
 import no.nav.dagpenger.soknad.orkestrator.utils.mars
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.ObjectMapper
 import java.time.ZonedDateTime
 import java.util.UUID
 

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadPdfGenerertOgMellomlagretMottakTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadPdfGenerertOgMellomlagretMottakTest.kt
@@ -36,7 +36,7 @@ class SøknadPdfGenerertOgMellomlagretMottakTest {
         rapidsConnection.inspektør.size shouldBe 1
         with(rapidsConnection.inspektør) {
             message(0)["søknadId"].asUUID() shouldBe søknadId
-            message(0)["ident"].asText() shouldBe ident
+            message(0)["ident"].asString() shouldBe ident
             message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV] shouldNotBe null
         }
     }
@@ -49,9 +49,9 @@ class SøknadPdfGenerertOgMellomlagretMottakTest {
 
         with(rapidsConnection.inspektør) {
             message(0)["søknadId"].asUUID() shouldBe søknadId
-            message(0)["ident"].asText() shouldBe ident
+            message(0)["ident"].asString() shouldBe ident
             message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV] shouldNotBe null
-            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV]["hovedDokument"]["skjemakode"].asText() shouldBe "04-16.04"
+            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV]["hovedDokument"]["skjemakode"].asString() shouldBe "04-16.04"
         }
     }
 
@@ -63,9 +63,9 @@ class SøknadPdfGenerertOgMellomlagretMottakTest {
 
         with(rapidsConnection.inspektør) {
             message(0)["søknadId"].asUUID() shouldBe søknadId
-            message(0)["ident"].asText() shouldBe ident
+            message(0)["ident"].asString() shouldBe ident
             message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV] shouldNotBe null
-            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV]["hovedDokument"]["skjemakode"].asText() shouldBe "04-01.04"
+            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV]["hovedDokument"]["skjemakode"].asString() shouldBe "04-01.04"
         }
     }
 
@@ -77,9 +77,9 @@ class SøknadPdfGenerertOgMellomlagretMottakTest {
 
         with(rapidsConnection.inspektør) {
             message(0)["søknadId"].asUUID() shouldBe søknadId
-            message(0)["ident"].asText() shouldBe ident
+            message(0)["ident"].asString() shouldBe ident
             message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV] shouldNotBe null
-            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV]["hovedDokument"]["skjemakode"].asText() shouldBe "04-16.03"
+            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV]["hovedDokument"]["skjemakode"].asString() shouldBe "04-16.03"
         }
     }
 
@@ -90,9 +90,9 @@ class SøknadPdfGenerertOgMellomlagretMottakTest {
         rapidsConnection.sendTestMessage(genererOgMellomlagreSøknadPdfLøsning)
         with(rapidsConnection.inspektør) {
             message(0)["søknadId"].asUUID() shouldBe søknadId
-            message(0)["ident"].asText() shouldBe ident
+            message(0)["ident"].asString() shouldBe ident
             message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV] shouldNotBe null
-            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV]["hovedDokument"]["skjemakode"].asText() shouldBe "04-01.03"
+            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV]["hovedDokument"]["skjemakode"].asString() shouldBe "04-01.03"
         }
     }
 

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadPdfGenerertOgMellomlagretMottakTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadPdfGenerertOgMellomlagretMottakTest.kt
@@ -37,7 +37,7 @@ class SøknadPdfGenerertOgMellomlagretMottakTest {
         with(rapidsConnection.inspektør) {
             message(0)["søknadId"].asUUID() shouldBe søknadId
             message(0)["ident"].asText() shouldBe ident
-            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV].asText() shouldNotBe null
+            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV] shouldNotBe null
         }
     }
 
@@ -50,7 +50,7 @@ class SøknadPdfGenerertOgMellomlagretMottakTest {
         with(rapidsConnection.inspektør) {
             message(0)["søknadId"].asUUID() shouldBe søknadId
             message(0)["ident"].asText() shouldBe ident
-            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV].asText() shouldNotBe null
+            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV] shouldNotBe null
             message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV]["hovedDokument"]["skjemakode"].asText() shouldBe "04-16.04"
         }
     }
@@ -64,7 +64,7 @@ class SøknadPdfGenerertOgMellomlagretMottakTest {
         with(rapidsConnection.inspektør) {
             message(0)["søknadId"].asUUID() shouldBe søknadId
             message(0)["ident"].asText() shouldBe ident
-            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV].asText() shouldNotBe null
+            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV] shouldNotBe null
             message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV]["hovedDokument"]["skjemakode"].asText() shouldBe "04-01.04"
         }
     }
@@ -78,7 +78,7 @@ class SøknadPdfGenerertOgMellomlagretMottakTest {
         with(rapidsConnection.inspektør) {
             message(0)["søknadId"].asUUID() shouldBe søknadId
             message(0)["ident"].asText() shouldBe ident
-            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV].asText() shouldNotBe null
+            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV] shouldNotBe null
             message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV]["hovedDokument"]["skjemakode"].asText() shouldBe "04-16.03"
         }
     }
@@ -91,7 +91,7 @@ class SøknadPdfGenerertOgMellomlagretMottakTest {
         with(rapidsConnection.inspektør) {
             message(0)["søknadId"].asUUID() shouldBe søknadId
             message(0)["ident"].asText() shouldBe ident
-            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV].asText() shouldNotBe null
+            message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV] shouldNotBe null
             message(0)[BehovForJournalføringAvSøknadPdfOgVedlegg.BEHOV]["hovedDokument"]["skjemakode"].asText() shouldBe "04-01.03"
         }
     }

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/SøknadServiceTest.kt
@@ -83,8 +83,8 @@ class SøknadServiceTest {
             søknadService.opprettOgLagreKomplettSøknaddata(ident = ident, søknadId = søknadId, seksjoner = seksjoner)
 
         verify(exactly = 1) { søknadRepository.lagreKomplettSøknadData(søknadId, any()) }
-        søknadData["ident"].asText() shouldBe ident
-        søknadData["søknadId"].asText() shouldBe søknadId.toString()
+        søknadData["ident"].asString() shouldBe ident
+        søknadData["søknadId"].asString() shouldBe søknadId.toString()
         søknadData["seksjoner"] shouldBe seksjoner
     }
 
@@ -96,9 +96,9 @@ class SøknadServiceTest {
 
         with(testRapid.inspektør) {
             size shouldBe 1
-            field(0, "@event_name").asText() shouldBe "søknad_innsendt"
-            field(0, "søknadId").asText() shouldBe søknadId.toString()
-            field(0, "ident").asText() shouldBe ident
+            field(0, "@event_name").asString() shouldBe "søknad_innsendt"
+            field(0, "søknadId").asString() shouldBe søknadId.toString()
+            field(0, "ident").asString() shouldBe ident
         }
     }
 
@@ -119,10 +119,10 @@ class SøknadServiceTest {
         with(testRapid.inspektør) {
             size shouldBe 1
 
-            field(0, "@event_name").asText() shouldBe "søknad_endret_tilstand"
-            field(0, "gjeldendeTilstand").asText() shouldBe "Slettet"
-            field(0, "søknad_uuid").asText() shouldBe søknadId.toString()
-            field(0, "ident").asText() shouldBe ident
+            field(0, "@event_name").asString() shouldBe "søknad_endret_tilstand"
+            field(0, "gjeldendeTilstand").asString() shouldBe "Slettet"
+            field(0, "søknad_uuid").asString() shouldBe søknadId.toString()
+            field(0, "ident").asString() shouldBe ident
             testRapid.inspektør.message(0).has("søknadsdata") shouldBe false
         }
     }
@@ -183,7 +183,7 @@ class SøknadServiceTest {
         søknadService.sendInn(randomUUID(), ident)
 
         testRapid.inspektør.size shouldBe 1
-        testRapid.inspektør.message(0)["@event_name"].asText() shouldBe "søknad_klar_til_journalføring"
+        testRapid.inspektør.message(0)["@event_name"].asString() shouldBe "søknad_klar_til_journalføring"
     }
 
     @Test
@@ -206,21 +206,21 @@ class SøknadServiceTest {
         verify { søknadRepository.slettSøknadSomSystem(søknadId2, ident2, any()) }
         with(testRapid.inspektør) {
             size shouldBe 4
-            field(0, "@event_name").asText() shouldBe "søknad_slettet"
-            field(0, "søknad_uuid").asText() shouldBe søknadId1.toString()
-            field(0, "ident").asText() shouldBe ident1
+            field(0, "@event_name").asString() shouldBe "søknad_slettet"
+            field(0, "søknad_uuid").asString() shouldBe søknadId1.toString()
+            field(0, "ident").asString() shouldBe ident1
 
-            field(1, "@event_name").asText() shouldBe "søknad_endret_tilstand"
-            field(1, "søknad_uuid").asText() shouldBe søknadId1.toString()
-            field(1, "ident").asText() shouldBe ident1
+            field(1, "@event_name").asString() shouldBe "søknad_endret_tilstand"
+            field(1, "søknad_uuid").asString() shouldBe søknadId1.toString()
+            field(1, "ident").asString() shouldBe ident1
 
-            field(2, "@event_name").asText() shouldBe "søknad_slettet"
-            field(2, "søknad_uuid").asText() shouldBe søknadId2.toString()
-            field(2, "ident").asText() shouldBe ident2
+            field(2, "@event_name").asString() shouldBe "søknad_slettet"
+            field(2, "søknad_uuid").asString() shouldBe søknadId2.toString()
+            field(2, "ident").asString() shouldBe ident2
 
-            field(3, "@event_name").asText() shouldBe "søknad_endret_tilstand"
-            field(3, "søknad_uuid").asText() shouldBe søknadId2.toString()
-            field(3, "ident").asText() shouldBe ident2
+            field(3, "@event_name").asString() shouldBe "søknad_endret_tilstand"
+            field(3, "søknad_uuid").asString() shouldBe søknadId2.toString()
+            field(3, "ident").asString() shouldBe ident2
         }
     }
 

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/jobb/RekjørJournalføringForSøknaderJobbTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/jobb/RekjørJournalføringForSøknaderJobbTest.kt
@@ -39,13 +39,13 @@ class RekjørJournalføringForSøknaderJobbTest {
 
         testRapid.inspektør.size shouldBe 2
 
-        testRapid.inspektør.message(0)["@event_name"].asText() shouldBe "søknad_klar_til_journalføring"
-        testRapid.inspektør.message(0)["søknadId"].asText() shouldBe søknadId1.toString()
-        testRapid.inspektør.message(0)["ident"].asText() shouldBe ident1
+        testRapid.inspektør.message(0)["@event_name"].asString() shouldBe "søknad_klar_til_journalføring"
+        testRapid.inspektør.message(0)["søknadId"].asString() shouldBe søknadId1.toString()
+        testRapid.inspektør.message(0)["ident"].asString() shouldBe ident1
 
-        testRapid.inspektør.message(1)["@event_name"].asText() shouldBe "søknad_klar_til_journalføring"
-        testRapid.inspektør.message(1)["søknadId"].asText() shouldBe søknadId2.toString()
-        testRapid.inspektør.message(1)["ident"].asText() shouldBe ident2
+        testRapid.inspektør.message(1)["@event_name"].asString() shouldBe "søknad_klar_til_journalføring"
+        testRapid.inspektør.message(1)["søknadId"].asString() shouldBe søknadId2.toString()
+        testRapid.inspektør.message(1)["ident"].asString() shouldBe ident2
     }
 
     @Test
@@ -58,7 +58,7 @@ class RekjørJournalføringForSøknaderJobbTest {
         RekjørJournalføringForSøknaderJobb.kjørJobb(testRapid, søknadRepository, søknadIder)
 
         testRapid.inspektør.size shouldBe 1
-        testRapid.inspektør.message(0)["søknadId"].asText() shouldBe søknadId2.toString()
+        testRapid.inspektør.message(0)["søknadId"].asString() shouldBe søknadId2.toString()
     }
 
     @Test
@@ -72,7 +72,7 @@ class RekjørJournalføringForSøknaderJobbTest {
         RekjørJournalføringForSøknaderJobb.kjørJobb(testRapid, søknadRepository, søknadIder)
 
         testRapid.inspektør.size shouldBe 1
-        testRapid.inspektør.message(0)["søknadId"].asText() shouldBe søknadId2.toString()
+        testRapid.inspektør.message(0)["søknadId"].asString() shouldBe søknadId2.toString()
     }
 
     @Test
@@ -96,8 +96,8 @@ class RekjørJournalføringForSøknaderJobbTest {
         RekjørJournalføringForSøknaderJobb.kjørJobb(testRapid, søknadRepository, søknadIder)
 
         testRapid.inspektør.size shouldBe 2
-        testRapid.inspektør.message(0)["søknadId"].asText() shouldBe søknadId1.toString()
-        testRapid.inspektør.message(1)["søknadId"].asText() shouldBe søknadId3.toString()
+        testRapid.inspektør.message(0)["søknadId"].asString() shouldBe søknadId1.toString()
+        testRapid.inspektør.message(1)["søknadId"].asString() shouldBe søknadId3.toString()
     }
 
     @Test

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/melding/SøknadEndretTilstandMeldingTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/melding/SøknadEndretTilstandMeldingTest.kt
@@ -51,8 +51,8 @@ class SøknadEndretTilstandMeldingTest {
         val seksjonsvarJson = objectMapper.readTree(filtrertArbeidsforhold)
         val seksjonsvarResponse = seksjonsvarJson["seksjonsvar"]
 
-        seksjonsvarResponse["hvordanHarDuJobbet"].asText() shouldBe "fastArbeidstidIMindreEnn6Måneder"
-        seksjonsvarResponse["harDuJobbetIEtAnnetEøsLandSveitsEllerStorbritanniaILøpetAvDeSiste36Månedene"].asText() shouldBe "ja"
+        seksjonsvarResponse["hvordanHarDuJobbet"].asString() shouldBe "fastArbeidstidIMindreEnn6Måneder"
+        seksjonsvarResponse["harDuJobbetIEtAnnetEøsLandSveitsEllerStorbritanniaILøpetAvDeSiste36Månedene"].asString() shouldBe "ja"
     }
 
     @Test
@@ -208,7 +208,7 @@ class SøknadEndretTilstandMeldingTest {
     private fun hentSøknadsdataSomJson(
         søknadsdataJson: JsonNode,
         seksjonId: String,
-    ): JsonNode? = objectMapper.readTree(søknadsdataJson["søknadsdata"][seksjonId]["seksjonsdata"].asText())
+    ): JsonNode? = objectMapper.readTree(søknadsdataJson["søknadsdata"][seksjonId]["seksjonsdata"].asString())
 
     private fun hentSeksjonData(): Map<String, String> {
         @Suppress("ktlint:standard:max-line-length")

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/melding/SøknadEndretTilstandMeldingTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/melding/SøknadEndretTilstandMeldingTest.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.soknad.orkestrator.søknad.melding
 
-import com.fasterxml.jackson.databind.JsonNode
 import io.kotest.assertions.json.shouldContainJsonKey
 import io.kotest.assertions.json.shouldNotContainJsonKey
 import io.kotest.matchers.nulls.shouldBeNull
@@ -11,6 +10,7 @@ import no.nav.dagpenger.soknad.orkestrator.config.objectMapper
 import no.nav.dagpenger.soknad.orkestrator.søknad.Søknad
 import no.nav.dagpenger.soknad.orkestrator.søknad.seksjon.SeksjonMedTidstempler
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.JsonNode
 import java.time.LocalDateTime
 import java.util.UUID
 

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/MeldingOmEttersendingMottakTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/søknad/mottak/MeldingOmEttersendingMottakTest.kt
@@ -56,16 +56,16 @@ class MeldingOmEttersendingMottakTest {
         rapidsConnection.inspektør.size shouldBe 1
         val dokumentKravInnsendtMelding = rapidsConnection.inspektør.message(0)
 
-        dokumentKravInnsendtMelding["@event_name"].asText() shouldBe "dokumentkrav_innsendt"
-        dokumentKravInnsendtMelding["ident"].asText() shouldBe ident
-        dokumentKravInnsendtMelding["søknad_uuid"].asText() shouldBe søknadId.toString()
-        dokumentKravInnsendtMelding["innsendingsType"].asText() shouldBe "ETTERSENDT"
-        dokumentKravInnsendtMelding["ferdigBesvart"].asText() shouldBe "true"
-        dokumentKravInnsendtMelding["kilde"].asText() shouldBe "orkestrator"
+        dokumentKravInnsendtMelding["@event_name"].asString() shouldBe "dokumentkrav_innsendt"
+        dokumentKravInnsendtMelding["ident"].asString() shouldBe ident
+        dokumentKravInnsendtMelding["søknad_uuid"].asString() shouldBe søknadId.toString()
+        dokumentKravInnsendtMelding["innsendingsType"].asString() shouldBe "ETTERSENDT"
+        dokumentKravInnsendtMelding["ferdigBesvart"].asString() shouldBe "true"
+        dokumentKravInnsendtMelding["kilde"].asString() shouldBe "orkestrator"
         dokumentKravInnsendtMelding["dokumentkrav"].size() shouldBe 1
-        dokumentKravInnsendtMelding["dokumentkrav"][0]["dokumentnavn"].asText() shouldBe "ArbeidsforholdArbeidsavtale"
-        dokumentKravInnsendtMelding["dokumentkrav"][0]["skjemakode"].asText() shouldBe "O2"
-        dokumentKravInnsendtMelding["dokumentkrav"][0]["valg"].asText() shouldBe "ETTERSENDT"
+        dokumentKravInnsendtMelding["dokumentkrav"][0]["dokumentnavn"].asString() shouldBe "ArbeidsforholdArbeidsavtale"
+        dokumentKravInnsendtMelding["dokumentkrav"][0]["skjemakode"].asString() shouldBe "O2"
+        dokumentKravInnsendtMelding["dokumentkrav"][0]["valg"].asString() shouldBe "ETTERSENDT"
     }
 
     @Test

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/ErBooleanTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/ErBooleanTest.kt
@@ -22,11 +22,17 @@ class ErBooleanTest {
             .JsonMapper()
             .readTree("false")
 
+    val vetIkkeNode =
+        tools.jackson.databind.json
+            .JsonMapper()
+            .readTree("\"vetikke\"")
+
     @Test
     fun testErBoolean() {
         assertTrue(jaNode.erBoolean())
         assertFalse(neiNode.erBoolean())
         assertTrue(trueNode.erBoolean())
         assertFalse(falseNode.erBoolean())
+        assertFalse(vetIkkeNode.erBoolean())
     }
 }

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/ErBooleanTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/ErBooleanTest.kt
@@ -6,20 +6,20 @@ import kotlin.test.Test
 
 class ErBooleanTest {
     val jaNode =
-        com.fasterxml.jackson.databind
-            .ObjectMapper()
+        tools.jackson.databind.json
+            .JsonMapper()
             .readTree("\"ja\"")
     val neiNode =
-        com.fasterxml.jackson.databind
-            .ObjectMapper()
+        tools.jackson.databind.json
+            .JsonMapper()
             .readTree("\"nei\"")
     val trueNode =
-        com.fasterxml.jackson.databind
-            .ObjectMapper()
+        tools.jackson.databind.json
+            .JsonMapper()
             .readTree("true")
     val falseNode =
-        com.fasterxml.jackson.databind
-            .ObjectMapper()
+        tools.jackson.databind.json
+            .JsonMapper()
             .readTree("false")
 
     @Test

--- a/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/TestApplication.kt
+++ b/src/test/kotlin/no/nav/dagpenger/soknad/orkestrator/utils/TestApplication.kt
@@ -1,12 +1,17 @@
 package no.nav.dagpenger.soknad.orkestrator.utils
 
-import com.github.navikt.tbd_libs.naisful.test.TestContext
-import com.github.navikt.tbd_libs.naisful.test.naisfulTestApp
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.jackson3.jackson
 import io.ktor.server.application.Application
-import io.micrometer.prometheusmetrics.PrometheusConfig
-import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
-import no.nav.dagpenger.soknad.orkestrator.config.objectMapper
+import io.ktor.server.application.install
+import io.ktor.server.testing.testApplication
+import no.nav.dagpenger.soknad.orkestrator.config.configure
 import no.nav.security.mock.oauth2.MockOAuth2Server
+
+class TestContext(
+    val client: HttpClient,
+)
 
 object TestApplication {
     private const val TOKENX_ISSUER_ID = "tokenx"
@@ -51,12 +56,21 @@ object TestApplication {
         System.setProperty("azure-app.client-id", CLIENT_ID)
         System.setProperty("azure-app.well-known-url", "${mockOAuth2Server.wellKnownUrl(AZUREAD_ISSUER_ID)}")
 
-        return naisfulTestApp(
-            testApplicationModule = moduleFunction,
-            meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT),
-            objectMapper = objectMapper,
-        ) {
-            test()
+        testApplication {
+            application {
+                install(io.ktor.server.plugins.contentnegotiation.ContentNegotiation) {
+                    jackson { configure() }
+                }
+
+                moduleFunction()
+            }
+            val client =
+                createClient {
+                    install(ContentNegotiation) {
+                        jackson { configure() }
+                    }
+                }
+            TestContext(client).test()
         }
     }
 }


### PR DESCRIPTION
- Erstatter com.fasterxml.jackson med tools.jackson i alle filer
- JsonNode.map/filter/any/single {} → .values()... (Iterable fjernet i Jackson 3)
- WRITE_DATES_AS_TIMESTAMPS → DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS
- JavaTimeModule er nå auto-registrert; eksplisitt registerModules() fjernet
- Ktor-plugin: jackson → jackson3 (io.ktor.serialization.jackson3)
- Gradle version catalog oppdatert med Jackson 3-koordinater

Fikser i tillegg en bug i eøsBostedsland: folkeregistrertAdresseErNorgeStemmerDet hentes med findPath().asText() siden feltet er lovlig fraværende for brukere som ikke er folkeregistrert i Norge (felt vises kun når landFraPdl === 'NORGE').